### PR TITLE
Very Draft: Picker24/feature/user projections

### DIFF
--- a/configs/Samples/SamplePDFDune_FHC_numuselec.yaml
+++ b/configs/Samples/SamplePDFDune_FHC_numuselec.yaml
@@ -26,12 +26,12 @@ Binning:
     - VarStr: "ELepRec" 
       Uniform: [25,0,5]
       Title: "E_{lep.}^{Rec} [GeV]"
-    - VarStr: "EHadRec" 
+    - VarStr: "mysillyvar" 
       Uniform: [25,0,5]
-      Title: "E_{had.}^{Vis} [GeV]"
-    - VarStr: "RecoNeutrinoEnergy" 
-      Uniform: [10,0.5,5.5]
-      Title: "E_{#nu}^{Rec} [GeV]"
+      Title: "dumbdumb"
+    # - VarStr: "RecoNeutrinoEnergy" 
+    #   Uniform: [10,0.5,5.5]
+    #   Title: "E_{#nu}^{Rec} [GeV]"
   # if you want to use the generic binning with a single 
   # axis, useful for calculated VarStr that cannot be referenced
   ForceGeneric: True

--- a/samplePDFDUNE/samplePDFDUNEBeamFD.h
+++ b/samplePDFDUNE/samplePDFDUNEBeamFD.h
@@ -26,7 +26,7 @@ public:
   ~samplePDFDUNEBeamFD();
 
   enum KinematicTypes {
-    kTrueNeutrinoEnergy,
+    kTrueNeutrinoEnergy = 0,
     kRecoNeutrinoEnergy,
     kTrueXPos,
     kTrueYPos,
@@ -40,14 +40,28 @@ public:
     kq3,
     kERecQE,
     kELepRec,
-    kEHadRec
+    kEHadRec,
+    kNDefaultProjections
   };
 
   //More robust getters to make plots in different variables, mode, osc channel, systematic weighting and with bin range 
   TH1D* get1DVarHist(KinematicTypes Var1, int fModeToFill=-1, int fSampleToFill=-1, int WeightStyle=0, TAxis* Axis=0);
   TH1D* get1DVarHist(KinematicTypes Var1, std::vector< std::vector<double> > Selection, int WeightStyle=0, TAxis* Axis=0);
     
+
+  struct UserProjection {
+    std::string name;
+    std::function<double(dunemc_base const&, int)> proj;
+  };
+
+  // add a user projection, capture the return value if you don't want to look the 
+  // KinematiceParameter value up by string
+  static int AddProjection(std::string const &, std::function<double(dunemc_base const&, int)>);
+
  protected:
+
+  static std::vector<UserProjection> user_projections;
+
   void Init();
   int setupExperimentMC(int iSample);
   void setupFDMC(int iSample);

--- a/src/EventRates.cpp
+++ b/src/EventRates.cpp
@@ -15,6 +15,7 @@
 #include "samplePDF/GenericBinningTools.h"
 
 #include "samplePDFDUNE/MaCh3DUNEFactory.h"
+#include "samplePDFDUNE/samplePDFDUNEBeamFD.h"
 
 void Write1DHistogramsToFile(std::string OutFileName,
                              std::vector<TH1D *> Histograms) {
@@ -66,6 +67,13 @@ int main(int argc, char *argv[]) {
   // ####################################################################################
   // Create samplePDFFD objects
 
+  samplePDFDUNEBeamFD::AddProjection(
+      "mysillyvar", [](dunemc_base const &dunemcSample, int iEvent) {
+        return (dunemcSample.rw_erec_shifted[iEvent] -
+                dunemcSample.rw_erec_lep[iEvent]) /
+               (dunemcSample.true_q0[iEvent]);
+      });
+
   std::vector<samplePDFFDBase *> DUNEPdfs;
   MakeMaCh3DuneInstance(fitMan.get(), DUNEPdfs, xsec, osc);
 
@@ -113,7 +121,6 @@ int main(int argc, char *argv[]) {
   }
 
   gc1->Print("GenericBinTest.pdf]");
-
 
   std::string OutFileName = GetFromManager<std::string>(
       fitMan->raw()["General"]["OutputFile"], "EventRatesOutput.root");


### PR DESCRIPTION
<img width="638" alt="image" src="https://github.com/user-attachments/assets/1153b2ac-fde5-4c8c-9ad3-9d24047ddb0c">


use like:

```c++
  samplePDFDUNEBeamFD::AddProjection(
      "mysillyvar", [](dunemc_base const &dunemcSample, int iEvent) {
        return (dunemcSample.rw_erec_shifted[iEvent] -
                dunemcSample.rw_erec_lep[iEvent]) /
               (dunemcSample.true_q0[iEvent]);
      });
```

static function on the analysis subclass (as it needs to know the 'structs type'), functions need to be registered *before* being instantiated by the factory

then in config:

```yaml
Binning:
  Axes:
    - VarStr: "ELepRec" 
      Uniform: [25,0,5]
      Title: "E_{lep.}^{Rec} [GeV]"
    - VarStr: "mysillyvar" 
      Uniform: [25,0,5]
      Title: "dumbdumb"
```