### PR TITLE
Read Previous MCMC via core code

### DIFF
--- a/src/Fit.cpp
+++ b/src/Fit.cpp
@@ -64,129 +64,37 @@ int main(int argc, char * argv[]) {
   }
   
   //###########################################################################################################
-  // Set covariance objects equal to output of previous chain
-  
-  std::vector<double> oscparstarts;
-  std::map<TString,std::vector<double> > parstarts;
-  int lastStep = 0;
+  //MCMC
+
+  std::unique_ptr<mcmc> MaCh3Fitter = std::make_unique<mcmc>(FitManager);
 
   bool StartFromPreviousChain = GetFromManager(FitManager->raw()["General"]["StartFromPos"], false);
-
-  if(StartFromPreviousChain) {//Start from values at the end of an already run chain
-    //Read in paramter names and values from file
-    MACH3LOG_INFO("MCMC getting starting position from {}",FitManager->raw()["General"]["PosFileName"].as<std::string>());
-    TFile *infile = TFile::Open(FitManager->raw()["General"]["PosFileName"].as<std::string>().c_str(), "READ");
-    TTree *posts = (TTree*)infile->Get("posteriors");
-    TObjArray* brlis = (TObjArray*)posts->GetListOfBranches();
-    int nbr = brlis->GetEntries();
-    TString branch_names[nbr];
-    double branch_vals[nbr];
-    int step_val;
-    for (int i = 0; i < nbr; ++i) {
-      TBranch *br = (TBranch*)brlis->At(i);
-      TString bname = br->GetName();
-      branch_names[i] = bname;
-      if(branch_names[i] == "step") {
-        posts->SetBranchAddress("step",&step_val);
-        continue;
-      }
-      MACH3LOG_INFO("Loading {}",bname);
-      posts->SetBranchAddress(branch_names[i], &branch_vals[i]);
-    }
-    posts->GetEntry(posts->GetEntries()-1);
-    std::map<TString,double> init_pars;
-    for (int i = 0; i < nbr; ++i) {
-      init_pars.insert( std::pair<TString, double>(branch_names[i], branch_vals[i]));
-    }
-    infile->Close();
-    delete infile;
-    
-    //Make vectors of parameter value for each covariance
-    std::vector<TString> covtypes;
-    covtypes.push_back("xsec");
- 
-    for(unsigned icov=0;icov<covtypes.size();icov++){
-      std::vector<double> covparstarts;
-      std::map<TString, double>::const_iterator it;
-      int iPar=0;
-      while(it != init_pars.end()){
-  	it = init_pars.find(covtypes[icov]+"_"+TString::Format("%d",iPar));
-  	if (it != init_pars.end()) {
-  	  covparstarts.push_back(it->second);
-  	}
-  	iPar++;
-      }
-      if(covparstarts.size()!=0) parstarts.insert(std::pair<TString,std::vector<double> >(covtypes[icov],covparstarts));
-      else MACH3LOG_INFO("Did not find any parameters in posterior tree for: {} assuming previous chain didn't use them",covtypes[icov]);
-    }
-
-    std::map<TString, double>::const_iterator itt;
-
-    // set the oscillation parameters
-    itt = init_pars.find("sin2th_12");
-    oscparstarts.push_back(itt->second);
-    itt = init_pars.find("sin2th_23");
-    oscparstarts.push_back(itt->second);
-    itt = init_pars.find("sin2th_13");
-    oscparstarts.push_back(itt->second);
-    itt = init_pars.find("delm2_12");
-    oscparstarts.push_back(itt->second);
-    itt = init_pars.find("delm2_23");
-    oscparstarts.push_back(itt->second);
-    itt = init_pars.find("delta_cp");
-    oscparstarts.push_back(itt->second);
-
-    lastStep = step_val;
-
+  if (StartFromPreviousChain) {
+    std::string PreviousChainPath = FitManager->raw()["General"]["PosFileName"].as<std::string>();
+    MACH3LOG_INFO("MCMC getting starting position from: {}",PreviousChainPath);
+    MaCh3Fitter->StartFromPreviousFit(PreviousChainPath);
   }
-
-  //###########################################################################################################
-  // Back to actual nominal for fit
-  // If starting from end values of a previous chain set everything to the values from there
-  // and do acceptStep() to update fParCurr with these values
-  //
-  if(GetFromManager(FitManager->raw()["General"]["StartFromPos"], false)) {
-    if(parstarts.find("xsec")!=parstarts.end()) {
-      xsec->setParameters(parstarts["xsec"]);
-      xsec->acceptStep();
-    }
-    else {xsec->setParameters();}
-  }
-  else {
-    xsec->setParameters();
-  }
-
-  //###########################################################################################################
-  // MCMC
-
-  //mcmc *MaCh3Fitter = new mcmc(FitManager);
-
-  std::unique_ptr<FitterBase> MaCh3Fitter = std::make_unique<mcmc>(FitManager);
-
-  //if(lastStep > 0) MaCh3Fitter->setInitialStepNumber(lastStep+1);
-
-  // add samples
+  
+  //Add samples
   for(auto Sample : DUNEPdfs){
     MaCh3Fitter->addSamplePDF(Sample);
   }
 
-  //start chain from random position
+  //Start chain from random position
   xsec->throwParameters();
   osc->throwParameters();
 
-  // add systematic objects
+  //Add systematic objects
+  MaCh3Fitter->addSystObj(osc);
   if (GetFromManager(FitManager->raw()["General"]["StatOnly"], false)){
-    MaCh3Fitter->addSystObj(osc);
     MACH3LOG_INFO("Running a stat-only fit so no systematics will be applied");
   }
   else {
-    MaCh3Fitter->addSystObj(osc);
     MaCh3Fitter->addSystObj(xsec);
   }
   
-  // run!
+  //Run fit
   MaCh3Fitter->runMCMC();
 
-
   return 0;
- }
+}


### PR DESCRIPTION
Remove the mess of code in the fitting executable which reads in the previous MCMC step. Use the functionality now added to core.

Addresses this issue: https://github.com/DUNE/MaCh3_DUNE/issues/20