### PR TITLE
Minor config and CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ add_subdirectory(src)
 
 add_library(MaCh3DUNEAll INTERFACE)
 set_target_properties(MaCh3DUNEAll PROPERTIES EXPORT_NAME All)
-target_link_libraries(MaCh3DUNEAll INTERFACE splinesDUNE SamplePDFDUNE MaCh3DUNECompilerOptions)
+target_link_libraries(MaCh3DUNEAll INTERFACE SamplePDFDUNE MaCh3DUNECompilerOptions)
 add_library(MaCh3DUNE::All ALIAS MaCh3DUNEAll)
 
 install(TARGETS MaCh3DUNEAll

--- a/configs/CovObjs/OscCov_PDG2021_v2.yaml
+++ b/configs/CovObjs/OscCov_PDG2021_v2.yaml
@@ -126,7 +126,7 @@ Systematics:
 
 
     DetID: 984
-    Error: 1.0
+    Error: -1.0
     FlatPrior: true
     ParameterBounds: [0, 999]
     ParameterGroup: Osc

--- a/samplePDFDUNE/CMakeLists.txt
+++ b/samplePDFDUNE/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT CPU_ONLY)
   set_target_properties(SamplePDFDUNE PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 endif()
 
-target_link_libraries(SamplePDFDUNE MaCh3::All MaCh3DUNECompilerOptions duneanaobj::all)
+target_link_libraries(SamplePDFDUNE splinesDUNE MaCh3::All MaCh3DUNECompilerOptions duneanaobj::all)
 
 target_include_directories(SamplePDFDUNE PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>

--- a/samplePDFDUNE/StructsDUNE.h
+++ b/samplePDFDUNE/StructsDUNE.h
@@ -1043,7 +1043,7 @@ inline std::string MaCh3mode_ToDUNEString(MaCh3_Mode i) {
     name = "ccqe";
     break;
   case kMaCh3_CC_Single_Kaon:
-    name = "ccsinglekaon";
+    name = "unknown";
     break;
   case kMaCh3_CC_DIS:
     name = "ccdis";


### PR DESCRIPTION
- Explicitly adding the dependence of `SamplePDFDUNE` on `splinesDUNE` to avoid linking issues
- Fixing the mach3 to DUNE mode list
- Removing the prior on the baseline in beam config as the allowed range does not match the central value