### PR TITLE
Add Simple Reconstructied Quantitiy Binning for Atmospherics

### DIFF
--- a/configs/Samples/AtmSample_nueselec.yaml
+++ b/configs/Samples/AtmSample_nueselec.yaml
@@ -8,8 +8,10 @@ SampleType: "Atm"
 #   - KinematicStr: "TrueZPos"
 #     Bounds: [ 50.0, 1244.0 ]
 Binning:
-  XVarStr: "TrueNeutrinoEnergy"
-  XVarBins: [0., 0.25, 0.5, 0.75, 1.,  1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 4.25, 4.5, 4.75, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 1e8]
+  XVarStr: "RecoCosineZ"
+  XVarBins: [-1, -0.78, -0.29, 0.31, 0.80, 1]
+  YVarStr: "RecoNeutrinoEnergy"
+  YVarBins: [0, 0.11, 0.19, 0.33, 0.62, 1.34, 3.35, 16.28, 1e8]
 SampleBools:
   IsELike: yes
 InputFiles:

--- a/configs/Samples/AtmSample_numuselec.yaml
+++ b/configs/Samples/AtmSample_numuselec.yaml
@@ -8,8 +8,10 @@ SampleType: "Atm"
 #   - KinematicStr: "TrueZPos"
 #     Bounds: [ 50.0, 1244.0 ]
 Binning:
-  XVarStr: "TrueNeutrinoEnergy"
-  XVarBins: [0., 0.25, 0.5, 0.75, 1.,  1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 4.25, 4.5, 4.75, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 100000.]
+  XVarStr: "RecoCosineZ"
+  XVarBins: [-1, -0.77, -0.26, 0.33, 0.81, 1]
+  YVarStr: "RecoNeutrinoEnergy"
+  YVarBins: [0, 0.19, 0.25, 0.37, 0.72, 1.31, 2.34, 4.47, 12.01, 1e8]
 SampleBools:
   IsELike: no
 InputFiles:

--- a/scripts/chooseBinningAtm.C
+++ b/scripts/chooseBinningAtm.C
@@ -1,0 +1,66 @@
+#include <TH2.h>
+
+// This macro should be fed 2D binned true x reco for some variable binned very finely.
+// This macro will try to combine bins in such a way as so "threshold" proportion of
+// truth will be in each reco bin.
+// Adjust "threshold" as needed
+
+const double threshold = 0.5;
+
+double efficiency(const TH2D *h, const int startBin, const int endBin) {
+    double inBin = 0;
+    double outBin = 0;
+    for (int i = startBin; i <= endBin; i++) {
+        for (int j = startBin; j <= endBin; j++) {
+            inBin += h->GetBinContent(i, j);
+        }
+    }
+    for (int i = startBin; i <= endBin; i++) {
+        for (int j = 1; j < startBin; j++) {
+            outBin += h->GetBinContent(i, j);
+        }
+    }
+    for (int i = startBin; i <= endBin; i++) {
+        for (int j = endBin+1; j <= h->GetNbinsY(); j++) {
+            outBin += h->GetBinContent(i, j);
+        }
+    }
+    return inBin / (inBin + outBin);
+}
+
+TH2D* flipHist(TH2D *h) {
+    TH2D *h2 = new TH2D("{h.GetName()}_flip", "{h.GetName()}_flip", h->GetNbinsY(),
+                        h->GetYaxis()->GetXmin(), h->GetYaxis()->GetXmax(), h->GetNbinsX(),
+                        h->GetXaxis()->GetXmin(), h->GetXaxis()->GetXmax());
+
+    for(int i = 1; i <= h->GetNbinsX(); i++) {
+        for(int j = 1; j <= h->GetNbinsY(); j++) {
+            h2->SetBinContent(j, i, h->GetBinContent(i, j));
+        }
+    }
+    return h2;
+}
+
+void chooseBinningAtm(std::string inFile, std::string histName, bool flip=false) {
+    TFile *file = TFile::Open(inFile.c_str());
+    TH2D *h = (TH2D *) file->Get(histName.c_str());
+
+    // Need this because issue https://github.com/mach3-software/MaCh3/issues/245
+    // Need to switch ordering of x-y to avoid segfaults for some variables
+    if (flip) {
+        h = flipHist(h);
+    }
+
+    TAxis *axis = h->GetXaxis();
+    
+    for (int i = 1; i <= h->GetNbinsX(); i++) {
+        for (int j = i; j <= h->GetNbinsX(); j++) {
+            double e = efficiency(h, i, j);
+            if (j == h->GetNbinsX() || e >= threshold) {
+                std::cout << axis->GetBinLowEdge(i) << " -> " << axis->GetBinLowEdge(j) + axis->GetBinWidth(j)
+                        << " : " << 100 * e << "%" << std::endl;
+                i = j + 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The binning is in `RecoCosineZ` and `RecoNeutrinoEnergy`, chosen by finding a binning with roughly 50% of truth in each reco bin for the two variables separately. 