### PR TITLE
added a cmake flag for mach3 core branch selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ endif()
 ##################################  MaCh3  ######################################
 #If MaCh3 was sourced find it, otherwise use CPM
 SET(MaCh3_FOUND FALSE)
-find_package(MaCh3 1.3.6 EXACT QUIET)
+
+set(MaCh3_CORE_BRANCH v1.4.8 CACHE STRING "Specify the MaCh3 core branch to use")
+message(STATUS "Using MaCh3_CORE_BRANCH: ${MaCh3_CORE_BRANCH}")
 
 if(NOT MaCh3_FOUND)
   cmessage(STATUS "Didn't find MaCh3, attempting to use built in MaCh3")
@@ -143,6 +145,7 @@ if(NOT MaCh3_FOUND)
       "USE_CPU ${USE_CPU}"
       "MaCh3_DEBUG_ENABLED ${DEBUG_ENABLED}"
       "MaCh3_MULTITHREAD_ENABLED ${MULTITHREAD_ENABLED}"
+      "MaCh3_CORE_BRANCH ${MaCh3_CORE_BRANCH}"
   )
 
   # Add LOG_LEVEL if defined
@@ -152,7 +155,7 @@ if(NOT MaCh3_FOUND)
   
   CPMAddPackage(
       NAME MaCh3
-      GIT_TAG "v1.3.6"
+      GIT_TAG ${MaCh3_CORE_BRANCH}
       GITHUB_REPOSITORY mach3-software/MaCh3
   )
 else()


### PR DESCRIPTION
Added a flag for being able to select MaCh3 tag/branch directly from the cmake command. If not given v1.4.8 will be used as default (I'm not sure this should be correct default, can change if not recommended) 