### PR TITLE
bugfix: Don't throw XSec parameters for Stats Only and Set Fake Data to Asimov

### DIFF
--- a/Apps/Fit.cpp
+++ b/Apps/Fit.cpp
@@ -42,13 +42,13 @@ int main(int argc, char * argv[]) {
   auto OutputFile = std::unique_ptr<TFile>(TFile::Open(OutputFileName.c_str(), "RECREATE"));
   OutputFile->cd();
 
+  osc->setParameters(FitManager->raw()["General"]["OscillationParameters"].as<std::vector<double>>());
   for (unsigned sample_i = 0 ; sample_i < DUNEPdfs.size() ; ++sample_i) {
     
     std::string name = DUNEPdfs[sample_i]->GetName();
     sample_names.push_back(name);
     TString NameTString = TString(name.c_str());
     
-    osc->setParameters();
     DUNEPdfs[sample_i] -> reweight();
     if (DUNEPdfs[sample_i]->GetNDim() == 1){
       PredictionHistograms.push_back(static_cast<TH1*>(DUNEPdfs[sample_i] -> get1DHist() -> Clone(NameTString+"_unosc")));
@@ -83,7 +83,9 @@ int main(int argc, char * argv[]) {
 
   //Start chain from random position unless continuing a chain
   if(!StartFromPreviousChain){
-    xsec->throwParameters();
+    if (!GetFromManager(FitManager->raw()["General"]["StatOnly"], false))
+      xsec->throwParameters();
+    osc->setParameters();
     osc->throwParameters();
   }
   


### PR DESCRIPTION

# Pull request description

Recently in the Slack, I discussed "convergence issues" I was having with atmospheric neutrino fits. Turns out it was caused by `xsec` getting thrown during stats only fits, then being in some random weird state. Some chains appeared to be "stuck" somewhere because they were actually approaching a different posterior.

Also, I correctly set the fake data to the Asimov point here, instead of the prior point. Later when `throwParameters` is called for the oscillation parameters, I reset the parameters to the prior point first, since we shouldn't "know" the true point there.