### PR TITLE
feat: Atmospheric Exposure

### DIFF
--- a/Configs/Samples/AtmSample_AllMC.yaml
+++ b/Configs/Samples/AtmSample_AllMC.yaml
@@ -1,28 +1,27 @@
 ---
-SampleTitle: "numuselec"
+SampleTitle: "All"
 SampleType: "Atm"
-# SelectionCuts:
-#   - KinematicStr: "TrueXPos"
-#     Bounds: [ -310.0, 310.0 ]
-#   - KinematicStr: "TrueYPos"
-#     Bounds: [ -550.0, 550.0 ]
-#   - KinematicStr: "TrueZPos"
-#     Bounds: [ 50.0, 1244.0 ]
+MaCh3ModeConfig: "Configs/CovObjs/MaCh3Modes.yaml"
+SampleName: "ATM"
+
 Binning:
   XVarStr: "TrueNeutrinoEnergy"
   XVarBins: [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 4.25, 4.5, 4.75, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 100000.]
-SampleBools:
+
+SampleOptions:
   IsELike: no
+  ExposureScaling: 1.0
+
 InputFiles:
   mtupleprefix: "Inputs/Atmospherics/CAFs/atm_hd"
   mtuplesuffix: ".root"
   splineprefix: ""
   splinesuffix: ""
-SampleName: "ATM"
+
 NuOsc:
   NuOscConfigFile: "Configs/NuOsc/CUDAProb3.yaml"
   EqualBinningPerOscChannel: true
-NSubSamples: 12
+
 SubSamples:
   - name: "nue_x_nue"
     mtuplefile: "nue_x_nue"

--- a/Configs/Samples/AtmSample_ncselec.yaml
+++ b/Configs/Samples/AtmSample_ncselec.yaml
@@ -1,28 +1,27 @@
 ---
-SampleTitle: "numuselec"
+SampleTitle: "ncselec"
 SampleType: "Atm"
-# SelectionCuts:
-#   - KinematicStr: "TrueXPos"
-#     Bounds: [ -310.0, 310.0 ]
-#   - KinematicStr: "TrueYPos"
-#     Bounds: [ -550.0, 550.0 ]
-#   - KinematicStr: "TrueZPos"
-#     Bounds: [ 50.0, 1244.0 ]
+MaCh3ModeConfig: "Configs/CovObjs/MaCh3Modes.yaml"
+SampleName: "ATM"
+
 Binning:
   XVarStr: "TrueNeutrinoEnergy"
   XVarBins: [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 4.25, 4.5, 4.75, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 100000.]
-SampleBools:
+
+SampleOptions:
   IsELike: no
+  ExposureScaling: 1.0
+
 InputFiles:
   mtupleprefix: "Inputs/Atmospherics/CAFs/atm_hd"
   mtuplesuffix: "_ncselec.root"
   splineprefix: ""
   splinesuffix: ""
-SampleName: "ATM"
+
 NuOsc:
   NuOscConfigFile: "Configs/NuOsc/CUDAProb3.yaml"
   EqualBinningPerOscChannel: true
-NSubSamples: 12
+
 SubSamples:
   - name: "nue_x_nue"
     mtuplefile: "nue_x_nue"

--- a/Configs/Samples/AtmSample_nueselec.yaml
+++ b/Configs/Samples/AtmSample_nueselec.yaml
@@ -10,8 +10,9 @@ Binning:
   YVarStr: "RecoNeutrinoEnergy"
   YVarBins: [0, 0.11, 0.17, 0.26, 0.4, 0.63, 1.03, 1.71, 2.94, 5.48, 1e8]
 
-SampleBools:
+SampleOptions:
   IsELike: yes
+  ExposureScaling: 1.0
 
 InputFiles:
   mtupleprefix: "Inputs/Atmospherics/CAFs/atm_hd"

--- a/Configs/Samples/AtmSample_numuselec.yaml
+++ b/Configs/Samples/AtmSample_numuselec.yaml
@@ -10,8 +10,9 @@ Binning:
   YVarStr: "RecoNeutrinoEnergy"
   YVarBins: [0, 0.23, 0.31, 0.47, 0.81, 1.28, 1.99, 3.17, 5.38, 11.54, 1e8]
 
-SampleBools:
+SampleOptions:
   IsELike: no
+  ExposureScaling: 1.0
 
 InputFiles:
   mtupleprefix: "Inputs/Atmospherics/CAFs/atm_hd"

--- a/Samples/SampleHandlerAtm.cpp
+++ b/Samples/SampleHandlerAtm.cpp
@@ -19,7 +19,8 @@ SampleHandlerAtm::~SampleHandlerAtm() {
 void SampleHandlerAtm::Init() {
   dunemcSamples.resize(nSamples,dunemc_base());
   
-  IsELike = SampleManager->raw()["SampleBools"]["IsELike"].as<bool>();
+  IsELike = Get<bool>(SampleManager->raw()["SampleOptions"]["IsELike"],__FILE__,__LINE__);
+  ExposureScaling = Get<double>(SampleManager->raw()["SampleOptions"]["ExposureScaling"],__FILE__,__LINE__);
 }
 
 void SampleHandlerAtm::SetupSplines() {
@@ -29,11 +30,12 @@ void SampleHandlerAtm::SetupSplines() {
 void SampleHandlerAtm::SetupWeightPointers() {
   for (size_t i = 0; i < dunemcSamples.size(); ++i) {
     for (int j = 0; j < dunemcSamples[i].nEvents; ++j) {
-      MCSamples[i].ntotal_weight_pointers[j] = 3;
+      MCSamples[i].ntotal_weight_pointers[j] = 4;
       MCSamples[i].total_weight_pointers[j].resize(MCSamples[i].ntotal_weight_pointers[j]);
       MCSamples[i].total_weight_pointers[j][0] = &(dunemcSamples[i].flux_w[j]);
       MCSamples[i].total_weight_pointers[j][1] = MCSamples[i].osc_w_pointer[j];
       MCSamples[i].total_weight_pointers[j][2] = &(MCSamples[i].xsec_w[j]);
+      MCSamples[i].total_weight_pointers[j][3] = &(ExposureScaling);
     }
   }
 }

--- a/Samples/SampleHandlerAtm.h
+++ b/Samples/SampleHandlerAtm.h
@@ -121,6 +121,9 @@ protected:
 
   /// Is the sample e-like
   bool IsELike;
+
+  /// Multiplicative scaling to scale from the assumed 400ktyr value in the CAF files
+  double ExposureScaling;
 };
 
 #endif


### PR DESCRIPTION
# Pull request description
Add a config option to scale the exposure of Atmospheric Samples. Exposure Scaling of 1.0 uses default assumption of 400ktyr as assumed in the CAFs

## Changes or fixes


## Examples