### PR TITLE
tidy: Remove cmake hack

### DIFF
--- a/Samples/CMakeLists.txt
+++ b/Samples/CMakeLists.txt
@@ -21,10 +21,6 @@ set_target_properties(SamplesDUNE PROPERTIES
   PUBLIC_HEADER "${HEADERS}"
   EXPORT_NAME SamplesDUNE)
 
-if(NOT CPU_ONLY)
-  set_target_properties(SamplesDUNE PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-endif()
-
 target_link_libraries(SamplesDUNE PUBLIC SplinesDUNE duneanaobj::all MaCh3::All MaCh3DUNECompilerOptions)
 target_link_libraries(SamplesDUNE PRIVATE DUNEMaCh3Warnings)
 


### PR DESCRIPTION
# Pull request description
CUDA_SEPARABLE_COMPILATION is no longer needed or never was.
Actually CUDA code is compiled at core, so DUNE doesn't need this.
T2K also doesn't need it and I removed it there long time ago.