### PR TITLE
feat: Add automatic tagging

### DIFF
--- a/.github/workflows/AutomaticTag.yml
+++ b/.github/workflows/AutomaticTag.yml
@@ -1,0 +1,41 @@
+---
+name: Tag new version
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tag-new-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect and tag version
+        id: tagger
+        uses: salsify/action-detect-and-tag-new-version@v2
+        with:
+          tag-template: "v{VERSION}"
+          version-command: |
+            # I hate regex... BUT we assume that the version is always in the format X.Y.Z 
+            # and that it is on a line containing "MaCh3DUNE_VERSION"
+            sed -nE 's/.*MaCh3DUNE_VERSION\s+([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt
+
+      - name: Create release
+        if: steps.tagger.outputs.tag != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.tagger.outputs.tag }}" \
+              --title "${{ steps.tagger.outputs.tag }}" \
+              --generate-notes


### PR DESCRIPTION
# Pull request description
Add automatic tag and release action to MaCh3 DUNE.

Now when a PR is pulled into main with the tag updated this will automatically generate a release + tag without manual input required

Note:
Finding the tag is... dodgy. For now I'm just using quick + dirty regex + sed to search the CMakeLists. This "works" but I'm sure there's a nicer way....