### PR TITLE
feat: add downsampling for ND and FD Beam samples

### DIFF
--- a/Configs/Samples/SampleHandler_FD_Beam.yaml
+++ b/Configs/Samples/SampleHandler_FD_Beam.yaml
@@ -5,6 +5,9 @@ BinningFile: "Configs/Samples/BeamParameterBinning.yaml"
 InputFiles:
   PrepSplineFile: false
 
+# number of events to skip when reading in the files. Default: 1 (no downsampling)
+downsamplingStep: 1
+
 NuOsc:
   NuOscConfigFile: "Configs/NuOsc/CUDAProb3Linear.yaml"
   EqualBinningPerOscChannel: false

--- a/Configs/Samples/SampleHandler_FD_Beam.yaml
+++ b/Configs/Samples/SampleHandler_FD_Beam.yaml
@@ -6,7 +6,7 @@ InputFiles:
   PrepSplineFile: false
 
 # number of events to skip when reading in the files. Default: 1 (no downsampling)
-downsamplingStep: 1
+DownsamplingStep: 1
 
 NuOsc:
   NuOscConfigFile: "Configs/NuOsc/CUDAProb3Linear.yaml"

--- a/Configs/Samples/SampleHandler_ND.yaml
+++ b/Configs/Samples/SampleHandler_ND.yaml
@@ -5,6 +5,9 @@ BinningFile: "Configs/Samples/BeamParameterBinning.yaml"
 InputFiles:
   PrepSplineFile: false
 
+# number of events to skip when reading in the files. Default: 1 (no downsampling)
+downsamplingStep: 1
+
 Samples:
   - "BeamND_FHC_CCnumu"
   - "BeamND_RHC_CCnumu"

--- a/Configs/Samples/SampleHandler_ND.yaml
+++ b/Configs/Samples/SampleHandler_ND.yaml
@@ -6,7 +6,7 @@ InputFiles:
   PrepSplineFile: false
 
 # number of events to skip when reading in the files. Default: 1 (no downsampling)
-downsamplingStep: 1
+DownsamplingStep: 1
 
 Samples:
   - "BeamND_FHC_CCnumu"

--- a/Docs/EventRates_Beam_downsamplingStep_10.log
+++ b/Docs/EventRates_Beam_downsamplingStep_10.log
@@ -1,0 +1,3878 @@
+[Monitor.cpp][info] ##################################
+[Monitor.cpp][info] Welcome to:  
+[Monitor.cpp][info]   __  __        _____ _     ____  
+[Monitor.cpp][info]  |  \/  |      / ____| |   |___ \ 
+[Monitor.cpp][info]  | \  / | __ _| |    | |__   __) |
+[Monitor.cpp][info]  | |\/| |/ _` | |    | '_ \ |__ < 
+[Monitor.cpp][info]  | |  | | (_| | |____| | | |___) |
+[Monitor.cpp][info]  |_|  |_|\__,_|\_____|_| |_|____/ 
+[Monitor.cpp][info] Version: 2.5.0
+[Monitor.cpp][info] ##################################
+[Monitor.cpp][info] Using following CPU:
+[Monitor.cpp][info] model name	: AMD EPYC 7502P 32-Core Processor
+[Monitor.cpp][info] cpu MHz		: 2500.000
+[Monitor.cpp][info] Architecture:                            x86_64
+[Monitor.cpp][info] L1d cache:                               1 MiB (32 instances)
+[Monitor.cpp][info] L1i cache:                               1 MiB (32 instances)
+[Monitor.cpp][info] L2 cache:                                16 MiB (32 instances)
+[Monitor.cpp][info] L3 cache:                                128 MiB (8 instances)
+[Monitor.cpp][info] Thread(s) per core:                      2
+[Monitor.cpp][info] CPU(s):                                  64
+[Monitor.cpp][info] With available threads                8
+[Manager.cpp][info] Setting config to be: Configs/EventRates_Beam.yaml
+[Manager.cpp][info] Config is now: 
+[Monitor.cpp][info] General:
+[Monitor.cpp][info]   OutputFile: DuneEventRates.root
+[Monitor.cpp][info]   DUNESamples:
+[Monitor.cpp][info]     - Configs/Samples/SampleHandler_FD_Beam.yaml
+[Monitor.cpp][info]     - Configs/Samples/SampleHandler_ND.yaml
+[Monitor.cpp][info]   OscillationParameters: [0.310, 0.582, 0.0224, 7.39E-5, 2.525E-3, -2.498, 1284.9, 2.848]
+[Monitor.cpp][info]   OscillatorConfigName: Configs/OscillatorObj.yaml
+[Monitor.cpp][info]   Systematics:
+[Monitor.cpp][info]     XsecCovFile:
+[Monitor.cpp][info]       - Configs/CovObjs/tdr_covs/Flux_ND+FD.yaml
+[Monitor.cpp][info]       - Configs/CovObjs/tdr_covs/Xsec_ND+FD.yaml
+[Monitor.cpp][info]       - Configs/CovObjs/tdr_covs/DetSysts_FD.yaml
+[Monitor.cpp][info]       - Configs/CovObjs/OscCov_PDG2021_v2.yaml
+[Monitor.cpp][info]     XsecCovName: xsec_cov
+[Monitor.cpp][info]     XsecStepScale: 0.05
+[Monitor.cpp][info]     XsecAtGen: false
+[Monitor.cpp][info]     NDCovFile: Configs/CovObjs/tdr_covs/det_sys_cov.root
+[Monitor.cpp][info]     UseCombinedNDCov: false
+[Monitor.cpp][info]     XsecFix: [baseline, density]
+[Monitor.cpp][info]   Fitter:
+[Monitor.cpp][info]     FitTestLikelihood: false
+[Monitor.cpp][info]   MCMC:
+[Monitor.cpp][info]     NSteps: 2000
+[Monitor.cpp][info]     AutoSave: 10000
+[Monitor.cpp][info]   Output:
+[Monitor.cpp][info]     FileName: TestEventRates.root
+[Monitor.cpp][info]     OUTPUTNAME: TestLLH.root
+[Monitor.cpp][info]   ProcessMCMC: No
+[Monitor.cpp][info]   Seed: 0
+[Monitor.cpp][info]   Debug: No
+[Monitor.cpp][info] LLHScan:
+[Monitor.cpp][info]   LLHScanBySample: false
+[Monitor.cpp][info]   LLHScanPoints: 10
+[Monitor.cpp][info]   ScanRanges: ~
+[Monitor.cpp][info] Tests:
+[Monitor.cpp][info]   SkipChecks: False
+[Monitor.cpp][info]   TestResultsFile: tests/test_results/EventRatesV2TDR.txt
+[MaCh3Factory.h][info] Initialising xsec_cov matrix
+[ParameterHandlerBase.cpp][info] Constructing instance of ParameterHandler using
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/Flux_ND+FD.yaml
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/Xsec_ND+FD.yaml
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/DetSysts_FD.yaml
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/OscCov_PDG2021_v2.yaml
+[ParameterHandlerBase.cpp][info] as an input
+[ParameterHandlerBase.cpp][info] Principal component analysis but given the threshold for the principal components to be less than 0, or greater than (or equal to) 1. This will not work
+[ParameterHandlerBase.cpp][info] Please specify a number between 0 and 1
+[ParameterHandlerBase.cpp][info] You specified: 
+[ParameterHandlerBase.cpp][info] Am instead calling the usual non-PCA constructor...
+[ParameterHandlerBase.cpp][info] Enabling Flipping for parameter sin2th_23 with value 0.5112
+[ParameterHandlerBase.cpp][info] Enabling Flipping for parameter delm2_23 with value 0
+[ParameterHandlerBase.cpp][info] Enabling CircularBounds for parameter delta_cp with range [-3.141592, 3.141592]
+[ParameterTunes.cpp][info] Found 1 tunes:
+[ParameterTunes.cpp][info]   Tune 0 Generated
+[ParameterHandlerBase.cpp][info] Created covariance matrix from files: 
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/Flux_ND+FD.yaml 
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/Xsec_ND+FD.yaml 
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/tdr_covs/DetSysts_FD.yaml 
+[ParameterHandlerBase.cpp][info] Configs/CovObjs/OscCov_PDG2021_v2.yaml 
+[ParameterHandlerBase.cpp][info] ----------------
+[ParameterHandlerBase.cpp][info] Found 301 systematics parameters in total
+[ParameterHandlerBase.cpp][info] ----------------
+[ParameterHandlerGeneric.cpp][info] #################################################
+[ParameterHandlerGeneric.cpp][info] Printing ParameterHandlerGeneric:
+[ParameterHandlerGeneric.cpp][info] ============================================================================================================================================================
+[ParameterHandlerGeneric.cpp][info] #     |  Name                                     |  Prior      |  Error      |  Lower      |  Upper      |  StepScale  |  SampleNames          |  Type      
+[ParameterHandlerGeneric.cpp][info] ------------------------------------------------------------------------------------------------------------------------------------------------------------
+[ParameterHandlerGeneric.cpp][info] 0     |  b_0                                      |  1          |  +/- 0.13   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 1     |  b_1                                      |  1          |  +/- 0.09   |  0          |  9999       |  0.005      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 2     |  b_2                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.003      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 3     |  b_3                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.001      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 4     |  b_4                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.001      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 5     |  b_5                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.001      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 6     |  b_6                                      |  1          |  +/- 0.07   |  0          |  9999       |  0.001      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 7     |  b_7                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.003      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 8     |  b_8                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.01       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 9     |  b_9                                      |  1          |  +/- 0.08   |  0          |  9999       |  0.02       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 10    |  b_10                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.06       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 11    |  b_11                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 12    |  b_12                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 13    |  b_13                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 14    |  b_14                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.02       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 15    |  b_15                                     |  1          |  +/- 0.12   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 16    |  b_16                                     |  1          |  +/- 0.18   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 17    |  b_17                                     |  1          |  +/- 0.19   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 18    |  b_18                                     |  1          |  +/- 0.35   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 19    |  b_19                                     |  1          |  +/- 0.15   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 20    |  b_20                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.5        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 21    |  b_21                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 22    |  b_22                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.2        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 23    |  b_23                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 24    |  b_24                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 25    |  b_25                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 26    |  b_26                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 27    |  b_27                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 28    |  b_28                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 29    |  b_29                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 30    |  b_30                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 31    |  b_31                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 32    |  b_32                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 33    |  b_33                                     |  1          |  +/- 0.13   |  0          |  9999       |  0.03       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 34    |  b_34                                     |  1          |  +/- 0.16   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 35    |  b_35                                     |  1          |  +/- 0.22   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 36    |  b_36                                     |  1          |  +/- 0.22   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 37    |  b_37                                     |  1          |  +/- 0.59   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 38    |  b_38                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 39    |  b_39                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 40    |  b_40                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 41    |  b_41                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 42    |  b_42                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 43    |  b_43                                     |  1          |  +/- 0.15   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 44    |  b_44                                     |  1          |  +/- 0.26   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 45    |  b_45                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 46    |  b_46                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 47    |  b_47                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 48    |  b_48                                     |  1          |  +/- 0.14   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 49    |  b_49                                     |  1          |  +/- 0.15   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 50    |  b_50                                     |  1          |  +/- 0.16   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 51    |  b_51                                     |  1          |  +/- 0.21   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 52    |  b_52                                     |  1          |  +/- 0.16   |  0          |  9999       |  0.3        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 53    |  b_53                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 54    |  b_54                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.09       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 55    |  b_55                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 56    |  b_56                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 57    |  b_57                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 58    |  b_58                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 59    |  b_59                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.09       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 60    |  b_60                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 61    |  b_61                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 62    |  b_62                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 63    |  b_63                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 64    |  b_64                                     |  1          |  +/- 0.13   |  0          |  9999       |  0.06       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 65    |  b_65                                     |  1          |  +/- 0.12   |  0          |  9999       |  0.7        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 66    |  b_66                                     |  1          |  +/- 0.12   |  0          |  9999       |  0.03       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 67    |  b_67                                     |  1          |  +/- 0.15   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 68    |  b_68                                     |  1          |  +/- 0.18   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 69    |  b_69                                     |  1          |  +/- 0.19   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 70    |  b_70                                     |  1          |  +/- 0.37   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 71    |  b_71                                     |  1          |  +/- 0.12   |  0          |  9999       |  0.4        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 72    |  b_72                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.06       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 73    |  b_73                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.02       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 74    |  b_74                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.01       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 75    |  b_75                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.005      |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 76    |  b_76                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.01       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 77    |  b_77                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.02       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 78    |  b_78                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.07       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 79    |  b_79                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 80    |  b_80                                     |  1          |  +/- 0.07   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 81    |  b_81                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 82    |  b_82                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 83    |  b_83                                     |  1          |  +/- 0.08   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 84    |  b_84                                     |  1          |  +/- 0.10   |  0          |  9999       |  0.1        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 85    |  b_85                                     |  1          |  +/- 0.09   |  0          |  9999       |  0.08       |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 86    |  b_86                                     |  1          |  +/- 0.13   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 87    |  b_87                                     |  1          |  +/- 0.21   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 88    |  b_88                                     |  1          |  +/- 0.21   |  0          |  9999       |  0.6        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 89    |  b_89                                     |  1          |  +/- 0.65   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 90    |  b_90                                     |  1          |  +/- 0.11   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 91    |  b_91                                     |  1          |  +/- 0.09   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 92    |  b_92                                     |  1          |  +/- 0.11   |  0          |  9999       |  0.9        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 93    |  b_93                                     |  1          |  +/- 0.13   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 94    |  b_94                                     |  1          |  +/- 0.16   |  0          |  9999       |  0.9        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 95    |  b_95                                     |  1          |  +/- 0.16   |  0          |  9999       |  0.9        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 96    |  b_96                                     |  1          |  +/- 0.24   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 97    |  b_97                                     |  1          |  +/- 0.09   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 98    |  b_98                                     |  1          |  +/- 0.07   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 99    |  b_99                                     |  1          |  +/- 0.08   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 100   |  b_100                                    |  1          |  +/- 0.13   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 101   |  b_101                                    |  1          |  +/- 0.13   |  0          |  9999       |  0.9        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 102   |  b_102                                    |  1          |  +/- 0.15   |  0          |  9999       |  1          |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 103   |  b_103                                    |  1          |  +/- 0.19   |  0          |  9999       |  0.9        |  BeamND*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 104   |  b_104                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 105   |  b_105                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 106   |  b_106                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 107   |  b_107                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 108   |  b_108                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 109   |  b_109                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 110   |  b_110                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 111   |  b_111                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 112   |  b_112                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 113   |  b_113                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 114   |  b_114                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 115   |  b_115                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 116   |  b_116                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 117   |  b_117                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 118   |  b_118                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 119   |  b_119                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 120   |  b_120                                    |  1          |  +/- 0.17   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 121   |  b_121                                    |  1          |  +/- 0.18   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 122   |  b_122                                    |  1          |  +/- 0.32   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 123   |  b_123                                    |  1          |  +/- 0.15   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 124   |  b_124                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 125   |  b_125                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 126   |  b_126                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 127   |  b_127                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 128   |  b_128                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 129   |  b_129                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 130   |  b_130                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 131   |  b_131                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 132   |  b_132                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 133   |  b_133                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 134   |  b_134                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 135   |  b_135                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 136   |  b_136                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 137   |  b_137                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 138   |  b_138                                    |  1          |  +/- 0.16   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 139   |  b_139                                    |  1          |  +/- 0.23   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 140   |  b_140                                    |  1          |  +/- 0.22   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 141   |  b_141                                    |  1          |  +/- 0.88   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 142   |  b_142                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 143   |  b_143                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 144   |  b_144                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 145   |  b_145                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 146   |  b_146                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 147   |  b_147                                    |  1          |  +/- 0.14   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 148   |  b_148                                    |  1          |  +/- 0.23   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 149   |  b_149                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 150   |  b_150                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 151   |  b_151                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 152   |  b_152                                    |  1          |  +/- 0.13   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 153   |  b_153                                    |  1          |  +/- 0.15   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 154   |  b_154                                    |  1          |  +/- 0.16   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 155   |  b_155                                    |  1          |  +/- 0.23   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 156   |  b_156                                    |  1          |  +/- 0.16   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 157   |  b_157                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 158   |  b_158                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 159   |  b_159                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 160   |  b_160                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 161   |  b_161                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 162   |  b_162                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 163   |  b_163                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 164   |  b_164                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 165   |  b_165                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 166   |  b_166                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 167   |  b_167                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 168   |  b_168                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 169   |  b_169                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 170   |  b_170                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 171   |  b_171                                    |  1          |  +/- 0.14   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 172   |  b_172                                    |  1          |  +/- 0.19   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 173   |  b_173                                    |  1          |  +/- 0.18   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 174   |  b_174                                    |  1          |  +/- 0.32   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 175   |  b_175                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 176   |  b_176                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 177   |  b_177                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 178   |  b_178                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 179   |  b_179                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 180   |  b_180                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 181   |  b_181                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 182   |  b_182                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 183   |  b_183                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 184   |  b_184                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 185   |  b_185                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 186   |  b_186                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 187   |  b_187                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 188   |  b_188                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 189   |  b_189                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 190   |  b_190                                    |  1          |  +/- 0.13   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 191   |  b_191                                    |  1          |  +/- 0.20   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 192   |  b_192                                    |  1          |  +/- 0.21   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 193   |  b_193                                    |  1          |  +/- 0.84   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 194   |  b_194                                    |  1          |  +/- 0.10   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 195   |  b_195                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 196   |  b_196                                    |  1          |  +/- 0.11   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 197   |  b_197                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 198   |  b_198                                    |  1          |  +/- 0.15   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 199   |  b_199                                    |  1          |  +/- 0.16   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 200   |  b_200                                    |  1          |  +/- 0.19   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 201   |  b_201                                    |  1          |  +/- 0.09   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 202   |  b_202                                    |  1          |  +/- 0.07   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 203   |  b_203                                    |  1          |  +/- 0.08   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 204   |  b_204                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 205   |  b_205                                    |  1          |  +/- 0.12   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 206   |  b_206                                    |  1          |  +/- 0.14   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 207   |  b_207                                    |  1          |  +/- 0.20   |  0          |  9999       |  0.3        |  BeamFD*              |  Norm      
+[ParameterHandlerGeneric.cpp][info] 208   |  MAQE                                     |  0          |  +/- 1.00   |  -4         |  4          |  0.002      |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 209   |  CCQEPauliSupViaKF                        |  0          |  +/- 1.00   |  0          |  1          |  0.02       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 210   |  MaCCRES                                  |  -0.36      |  +/- 0.09   |  -0.72      |  0          |  0.2        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 211   |  MvCCRES                                  |  0          |  +/- 1.00   |  -4         |  4          |  0.003      |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 212   |  MaNCRES                                  |  0          |  +/- 1.00   |  -4         |  4          |  0.2        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 213   |  MvNCRES                                  |  0          |  +/- 1.00   |  -4         |  4          |  6          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 214   |  ThetaDelta2NPi                           |  0          |  +/- 1.00   |  0          |  1          |  0.1        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 215   |  AhtBY                                    |  0          |  +/- 1.00   |  -3         |  3          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 216   |  BhtBY                                    |  0          |  +/- 1.00   |  -3         |  3          |  1          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 217   |  CV1uBY                                   |  0          |  +/- 1.00   |  -3         |  3          |  1          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 218   |  CV2uBY                                   |  0          |  +/- 1.00   |  -3         |  3          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 219   |  FrCEx_pi                                 |  0          |  +/- 1.00   |  -3         |  3          |  3          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 220   |  FrElas_pi                                |  0          |  +/- 1.00   |  -3         |  3          |  5          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 221   |  FrInel_pi                                |  0          |  +/- 1.00   |  -3         |  3          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 222   |  FrAbs_pi                                 |  0          |  +/- 1.00   |  -3         |  3          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 223   |  FrPiProd_pi                              |  0          |  +/- 1.00   |  -4         |  4          |  7          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 224   |  FrCEx_N                                  |  0          |  +/- 1.00   |  -4         |  4          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 225   |  FrElas_N                                 |  0          |  +/- 1.00   |  -4         |  4          |  4          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 226   |  FrInel_N                                 |  0          |  +/- 1.00   |  -4         |  4          |  3          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 227   |  FrAbs_N                                  |  0          |  +/- 1.00   |  -4         |  4          |  4          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 228   |  FrPiProd_N                               |  0          |  +/- 1.00   |  -4         |  4          |  7          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 229   |  E2p2h_A_nu                               |  0          |  +/- 1.00   |  -1         |  1          |  0.03       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 230   |  E2p2h_B_nu                               |  0          |  +/- 1.00   |  -1         |  1          |  0.07       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 231   |  E2p2h_A_nubar                            |  0          |  +/- 1.00   |  -1         |  1          |  0.02       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 232   |  E2p2h_B_nubar                            |  0          |  +/- 1.00   |  -1         |  1          |  0.03       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 233   |  C12ToAr40_2p2hScaling_nu                 |  0          |  +/- 1.00   |  0          |  1          |  0.3        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 234   |  C12ToAr40_2p2hScaling_nubar              |  0          |  +/- 1.00   |  0          |  1          |  0.1        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 235   |  NR_nu_n_CC_2pi                           |  0          |  +/- 1.00   |  -4         |  4          |  0.03       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 236   |  NR_nu_n_CC_3pi                           |  0          |  +/- 1.00   |  -4         |  4          |  0.06       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 237   |  NR_nu_p_CC_2pi                           |  0          |  +/- 1.00   |  -4         |  4          |  0.04       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 238   |  NR_nu_p_CC_3pi                           |  0          |  +/- 1.00   |  -4         |  4          |  0.05       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 239   |  NR_nu_np_CC_1pi                          |  -1.14      |  +/- 0.20   |  -1.22      |  -1.06      |  0.001      |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 240   |  NR_nu_n_NC_1pi                           |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 241   |  NR_nu_n_NC_2pi                           |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 242   |  NR_nu_n_NC_3pi                           |  0          |  +/- 1.00   |  -4         |  4          |  30         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 243   |  NR_nu_p_NC_1pi                           |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 244   |  NR_nu_p_NC_2pi                           |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 245   |  NR_nu_p_NC_3pi                           |  0          |  +/- 1.00   |  -4         |  4          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 246   |  NR_nubar_n_CC_1pi                        |  0          |  +/- 1.00   |  -4         |  4          |  4          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 247   |  NR_nubar_n_CC_2pi                        |  0          |  +/- 1.00   |  -4         |  4          |  0.3        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 248   |  NR_nubar_n_CC_3pi                        |  0          |  +/- 1.00   |  -4         |  4          |  1          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 249   |  NR_nubar_p_CC_1pi                        |  0          |  +/- 1.00   |  -4         |  4          |  0.1        |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 250   |  NR_nubar_p_CC_2pi                        |  0          |  +/- 1.00   |  -4         |  4          |  1          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 251   |  NR_nubar_p_CC_3pi                        |  0          |  +/- 1.00   |  -4         |  4          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 252   |  NR_nubar_n_NC_1pi                        |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 253   |  NR_nubar_n_NC_2pi                        |  0          |  +/- 1.00   |  -4         |  4          |  2          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 254   |  NR_nubar_n_NC_3pi                        |  0          |  +/- 1.00   |  -4         |  4          |  4          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 255   |  NR_nubar_p_NC_1pi                        |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 256   |  NR_nubar_p_NC_2pi                        |  0          |  +/- 1.00   |  -4         |  4          |  10         |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 257   |  NR_nubar_p_NC_3pi                        |  0          |  +/- 1.00   |  -4         |  4          |  5          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 258   |  BeRPA_A                                  |  0          |  +/- 1.00   |  -4         |  4          |  0.01       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 259   |  BeRPA_B                                  |  0          |  +/- 1.00   |  -4         |  4          |  0.01       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 260   |  BeRPA_D                                  |  0          |  +/- 1.00   |  -4         |  4          |  0.04       |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 261   |  nuenuebar_xsec_ratio                     |  1          |  +/- 1.00   |  0          |  1          |  5          |  BeamND*, BeamFD*     |  Spline    
+[ParameterHandlerGeneric.cpp][info] 262   |  nuemumu_xsec_ratio                       |  1          |  +/- 1.00   |  0          |  1          |  5          |  BeamND_FHC_CCnumu, BeamFD* |  Spline    
+[ParameterHandlerGeneric.cpp][info] 263   |  TotalEScaleFD                            |  0          |  +/- 0.02   |  -9999      |  9999       |  8          |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 264   |  TotalEScaleNotCCNumuFD                   |  0          |  +/- 0.02   |  -9999      |  9999       |  8          |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 265   |  TotalEScaleSqrtFD                        |  0          |  +/- 0.01   |  -9999      |  9999       |  16         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 266   |  TotalEScaleSqrtNotCCNumuFD               |  0          |  +/- 0.01   |  -9999      |  9999       |  16         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 267   |  TotalEScaleInvSqrtFD                     |  0          |  +/- 0.02   |  -9999      |  9999       |  18         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 268   |  TotalEScaleInvSqrtNotCCNumuFD            |  0          |  +/- 0.02   |  -9999      |  9999       |  18         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 269   |  HadEScaleFD                              |  0          |  +/- 0.05   |  -9999      |  9999       |  18         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 270   |  HadEScaleSqrtFD                          |  0          |  +/- 0.05   |  -9999      |  9999       |  20         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 271   |  HadEScaleInvSqrtFD                       |  0          |  +/- 0.05   |  -9999      |  9999       |  7          |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 272   |  MuEScaleFD                               |  0          |  +/- 0.02   |  -9999      |  9999       |  15         |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Functional
+[ParameterHandlerGeneric.cpp][info] 273   |  MuEScaleSqrtFD                           |  0          |  +/- 0.01   |  -9999      |  9999       |  20         |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Functional
+[ParameterHandlerGeneric.cpp][info] 274   |  MuEScaleInvSqrtFD                        |  0          |  +/- 0.02   |  -9999      |  9999       |  20         |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Functional
+[ParameterHandlerGeneric.cpp][info] 275   |  NEScaleFD                                |  0          |  +/- 0.20   |  -9999      |  9999       |  6          |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 276   |  NEScaleSqrtFD                            |  0          |  +/- 0.30   |  -9999      |  9999       |  12         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 277   |  NEScaleInvSqrtFD                         |  0          |  +/- 0.30   |  -9999      |  9999       |  10         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 278   |  EMEScaleFD                               |  0          |  +/- 0.03   |  -9999      |  9999       |  30         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 279   |  EMEScaleCCNueFD                          |  0          |  +/- 0.03   |  -9999      |  9999       |  30         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 280   |  EMEScaleSqrtFD                           |  0          |  +/- 0.03   |  -9999      |  9999       |  20         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 281   |  EMEScaleSqrtCCNueFD                      |  0          |  +/- 0.03   |  -9999      |  9999       |  20         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 282   |  EMEScaleInvSqrtFD                        |  0          |  +/- 0.03   |  -9999      |  9999       |  20         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 283   |  EMEScaleInvSqrtCCNueFD                   |  0          |  +/- 0.03   |  -9999      |  9999       |  20         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 284   |  HadResFD                                 |  0          |  +/- 0.02   |  -9999      |  9999       |  20         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 285   |  MuResFD                                  |  0          |  +/- 0.02   |  -9999      |  9999       |  9          |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Functional
+[ParameterHandlerGeneric.cpp][info] 286   |  NResFD                                   |  0          |  +/- 0.10   |  -9999      |  9999       |  17         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 287   |  EMResFD                                  |  0          |  +/- 0.02   |  -9999      |  9999       |  22         |  BeamFD_*             |  Functional
+[ParameterHandlerGeneric.cpp][info] 288   |  EMResCCNueFD                             |  0          |  +/- 0.02   |  -9999      |  9999       |  22         |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 289   |  RecoCVNNumuFD                            |  0          |  +/- 0.01   |  -9999      |  9999       |  8          |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Functional
+[ParameterHandlerGeneric.cpp][info] 290   |  RecoCVNNueFD                             |  0          |  +/- 0.01   |  -9999      |  9999       |  8          |  BeamFD_FHC_nue, BeamFD_RHC_nue |  Functional
+[ParameterHandlerGeneric.cpp][info] 291   |  NumuFVFD                                 |  1          |  +/- 0.01   |  0          |  9999       |  0.1        |  BeamFD_FHC_numu, BeamFD_RHC_numu |  Norm      
+[ParameterHandlerGeneric.cpp][info] 292   |  NueFVFD                                  |  1          |  +/- 0.01   |  0          |  9999       |  0.1        |  BeamFD_FHC_nue, FHC_RHC_nue |  Norm      
+[ParameterHandlerGeneric.cpp][info] 293   |  sin2th_12                                |  0.307      |  +/- 0.01   |  0          |  1          |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 294   |  sin2th_23                                |  0.546      |  +/- 0.02   |  0          |  1          |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 295   |  sin2th_13                                |  0.022      |  +/- 0.00   |  0          |  1          |  5          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 296   |  delm2_12                                 |  7.53e-05   |  +/- 0.00   |  -999       |  999        |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 297   |  delm2_23                                 |  0.002536   |  +/- 0.00   |  -999       |  999        |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 298   |  delta_cp                                 |  -1.601     |  +/- 6.28   |  -999       |  999        |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 299   |  baseline                                 |  1284.9     |  +/- 0.01   |  0          |  9999       |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] 300   |  density                                  |  2.6        |  +/- 0.01   |  0          |  999        |  1          |  BeamFD*, ATM         |  Oscillation
+[ParameterHandlerGeneric.cpp][info] ============================================================================================================================================================
+[ParameterHandlerGeneric.cpp][info] Normalisation parameters:  210
+[ParameterHandlerGeneric.cpp][info] ┌────┬──────────┬────────────────────────────────────────┬────────────────────┬────────────────────┬────────────────────┐
+[ParameterHandlerGeneric.cpp][info] │#   │Global #  │Name                                    │Int. mode           │Target              │pdg                 │
+[ParameterHandlerGeneric.cpp][info] ├────┼──────────┼────────────────────────────────────────┼────────────────────┼────────────────────┼────────────────────┤
+[ParameterHandlerGeneric.cpp][info] │0   │0         │b_0                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │1   │1         │b_1                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │2   │2         │b_2                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │3   │3         │b_3                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │4   │4         │b_4                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │5   │5         │b_5                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │6   │6         │b_6                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │7   │7         │b_7                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │8   │8         │b_8                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │9   │9         │b_9                                     │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │10  │10        │b_10                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │11  │11        │b_11                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │12  │12        │b_12                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │13  │13        │b_13                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │14  │14        │b_14                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │15  │15        │b_15                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │16  │16        │b_16                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │17  │17        │b_17                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │18  │18        │b_18                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │19  │19        │b_19                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │20  │20        │b_20                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │21  │21        │b_21                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │22  │22        │b_22                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │23  │23        │b_23                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │24  │24        │b_24                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │25  │25        │b_25                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │26  │26        │b_26                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │27  │27        │b_27                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │28  │28        │b_28                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │29  │29        │b_29                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │30  │30        │b_30                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │31  │31        │b_31                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │32  │32        │b_32                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │33  │33        │b_33                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │34  │34        │b_34                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │35  │35        │b_35                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │36  │36        │b_36                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │37  │37        │b_37                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │38  │38        │b_38                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │39  │39        │b_39                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │40  │40        │b_40                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │41  │41        │b_41                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │42  │42        │b_42                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │43  │43        │b_43                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │44  │44        │b_44                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │45  │45        │b_45                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │46  │46        │b_46                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │47  │47        │b_47                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │48  │48        │b_48                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │49  │49        │b_49                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │50  │50        │b_50                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │51  │51        │b_51                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │52  │52        │b_52                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │53  │53        │b_53                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │54  │54        │b_54                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │55  │55        │b_55                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │56  │56        │b_56                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │57  │57        │b_57                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │58  │58        │b_58                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │59  │59        │b_59                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │60  │60        │b_60                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │61  │61        │b_61                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │62  │62        │b_62                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │63  │63        │b_63                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │64  │64        │b_64                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │65  │65        │b_65                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │66  │66        │b_66                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │67  │67        │b_67                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │68  │68        │b_68                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │69  │69        │b_69                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │70  │70        │b_70                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │71  │71        │b_71                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │72  │72        │b_72                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │73  │73        │b_73                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │74  │74        │b_74                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │75  │75        │b_75                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │76  │76        │b_76                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │77  │77        │b_77                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │78  │78        │b_78                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │79  │79        │b_79                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │80  │80        │b_80                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │81  │81        │b_81                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │82  │82        │b_82                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │83  │83        │b_83                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │84  │84        │b_84                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │85  │85        │b_85                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │86  │86        │b_86                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │87  │87        │b_87                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │88  │88        │b_88                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │89  │89        │b_89                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │90  │90        │b_90                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │91  │91        │b_91                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │92  │92        │b_92                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │93  │93        │b_93                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │94  │94        │b_94                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │95  │95        │b_95                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │96  │96        │b_96                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │97  │97        │b_97                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │98  │98        │b_98                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │99  │99        │b_99                                    │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │100 │100       │b_100                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │101 │101       │b_101                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │102 │102       │b_102                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │103 │103       │b_103                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │104 │104       │b_104                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │105 │105       │b_105                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │106 │106       │b_106                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │107 │107       │b_107                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │108 │108       │b_108                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │109 │109       │b_109                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │110 │110       │b_110                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │111 │111       │b_111                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │112 │112       │b_112                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │113 │113       │b_113                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │114 │114       │b_114                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │115 │115       │b_115                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │116 │116       │b_116                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │117 │117       │b_117                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │118 │118       │b_118                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │119 │119       │b_119                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │120 │120       │b_120                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │121 │121       │b_121                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │122 │122       │b_122                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │123 │123       │b_123                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │124 │124       │b_124                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │125 │125       │b_125                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │126 │126       │b_126                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │127 │127       │b_127                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │128 │128       │b_128                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │129 │129       │b_129                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │130 │130       │b_130                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │131 │131       │b_131                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │132 │132       │b_132                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │133 │133       │b_133                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │134 │134       │b_134                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │135 │135       │b_135                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │136 │136       │b_136                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │137 │137       │b_137                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │138 │138       │b_138                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │139 │139       │b_139                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │140 │140       │b_140                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │141 │141       │b_141                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │142 │142       │b_142                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │143 │143       │b_143                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │144 │144       │b_144                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │145 │145       │b_145                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │146 │146       │b_146                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │147 │147       │b_147                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │148 │148       │b_148                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │149 │149       │b_149                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │150 │150       │b_150                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │151 │151       │b_151                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │152 │152       │b_152                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │153 │153       │b_153                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │154 │154       │b_154                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │155 │155       │b_155                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │156 │156       │b_156                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │157 │157       │b_157                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │158 │158       │b_158                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │159 │159       │b_159                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │160 │160       │b_160                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │161 │161       │b_161                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │162 │162       │b_162                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │163 │163       │b_163                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │164 │164       │b_164                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │165 │165       │b_165                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │166 │166       │b_166                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │167 │167       │b_167                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │168 │168       │b_168                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │169 │169       │b_169                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │170 │170       │b_170                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │171 │171       │b_171                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │172 │172       │b_172                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │173 │173       │b_173                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │174 │174       │b_174                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │175 │175       │b_175                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │176 │176       │b_176                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │177 │177       │b_177                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │178 │178       │b_178                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │179 │179       │b_179                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │180 │180       │b_180                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │181 │181       │b_181                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │182 │182       │b_182                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │183 │183       │b_183                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │184 │184       │b_184                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │185 │185       │b_185                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │186 │186       │b_186                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │187 │187       │b_187                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │188 │188       │b_188                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │189 │189       │b_189                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │190 │190       │b_190                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │191 │191       │b_191                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │192 │192       │b_192                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │193 │193       │b_193                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │194 │194       │b_194                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │195 │195       │b_195                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │196 │196       │b_196                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │197 │197       │b_197                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │198 │198       │b_198                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │199 │199       │b_199                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │200 │200       │b_200                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │201 │201       │b_201                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │202 │202       │b_202                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │203 │203       │b_203                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │204 │204       │b_204                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │205 │205       │b_205                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │206 │206       │b_206                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │207 │207       │b_207                                   │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │208 │291       │NumuFVFD                                │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] │209 │292       │NueFVFD                                 │all                 │all                 │all                 │
+[ParameterHandlerGeneric.cpp][info] └────┴──────────┴────────────────────────────────────────┴────────────────────┴────────────────────┴────────────────────┘
+[ParameterHandlerGeneric.cpp][info] Normalisation parameters KinematicCuts information
+[ParameterHandlerGeneric.cpp][info] ┌────┬──────────┬────────────────────────────────────────┬────────────────────┬────────────────────────────────────────┐
+[ParameterHandlerGeneric.cpp][info] │#   │Global #  │Name                                    │KinematicCut        │Value                                   │
+[ParameterHandlerGeneric.cpp][info] ├────┼──────────┼────────────────────────────────────────┼────────────────────┼────────────────────────────────────────┤
+[ParameterHandlerGeneric.cpp][info] │0   │0         │b_0                                     │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │1   │1         │b_1                                     │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │2   │2         │b_2                                     │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │3   │3         │b_3                                     │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │4   │4         │b_4                                     │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │5   │5         │b_5                                     │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │6   │6         │b_6                                     │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │7   │7         │b_7                                     │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │8   │8         │b_8                                     │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │9   │9         │b_9                                     │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │10  │10        │b_10                                    │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │11  │11        │b_11                                    │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │12  │12        │b_12                                    │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │13  │13        │b_13                                    │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │14  │14        │b_14                                    │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │15  │15        │b_15                                    │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │16  │16        │b_16                                    │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │17  │17        │b_17                                    │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │18  │18        │b_18                                    │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │19  │19        │b_19                                    │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │20  │20        │b_20                                    │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │21  │21        │b_21                                    │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │22  │22        │b_22                                    │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │23  │23        │b_23                                    │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │24  │24        │b_24                                    │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │25  │25        │b_25                                    │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │26  │26        │b_26                                    │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │27  │27        │b_27                                    │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │28  │28        │b_28                                    │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │29  │29        │b_29                                    │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │30  │30        │b_30                                    │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │31  │31        │b_31                                    │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │32  │32        │b_32                                    │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │33  │33        │b_33                                    │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │34  │34        │b_34                                    │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │35  │35        │b_35                                    │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │36  │36        │b_36                                    │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │37  │37        │b_37                                    │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │38  │38        │b_38                                    │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │39  │39        │b_39                                    │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │40  │40        │b_40                                    │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │41  │41        │b_41                                    │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │42  │42        │b_42                                    │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │43  │43        │b_43                                    │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │44  │44        │b_44                                    │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │45  │45        │b_45                                    │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │46  │46        │b_46                                    │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │47  │47        │b_47                                    │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │48  │48        │b_48                                    │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │49  │49        │b_49                                    │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │50  │50        │b_50                                    │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │51  │51        │b_51                                    │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │52  │52        │b_52                                    │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │53  │53        │b_53                                    │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │54  │54        │b_54                                    │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │55  │55        │b_55                                    │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │56  │56        │b_56                                    │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │57  │57        │b_57                                    │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │58  │58        │b_58                                    │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │59  │59        │b_59                                    │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │60  │60        │b_60                                    │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │61  │61        │b_61                                    │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │62  │62        │b_62                                    │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │63  │63        │b_63                                    │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │64  │64        │b_64                                    │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │65  │65        │b_65                                    │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │66  │66        │b_66                                    │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │67  │67        │b_67                                    │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │68  │68        │b_68                                    │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │69  │69        │b_69                                    │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │70  │70        │b_70                                    │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │71  │71        │b_71                                    │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │72  │72        │b_72                                    │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │73  │73        │b_73                                    │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │74  │74        │b_74                                    │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │75  │75        │b_75                                    │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │76  │76        │b_76                                    │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │77  │77        │b_77                                    │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │78  │78        │b_78                                    │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │79  │79        │b_79                                    │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │80  │80        │b_80                                    │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │81  │81        │b_81                                    │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │82  │82        │b_82                                    │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │83  │83        │b_83                                    │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │84  │84        │b_84                                    │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │85  │85        │b_85                                    │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │86  │86        │b_86                                    │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │87  │87        │b_87                                    │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │88  │88        │b_88                                    │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │89  │89        │b_89                                    │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │90  │90        │b_90                                    │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │91  │91        │b_91                                    │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │92  │92        │b_92                                    │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │93  │93        │b_93                                    │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │94  │94        │b_94                                    │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │95  │95        │b_95                                    │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │96  │96        │b_96                                    │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │97  │97        │b_97                                    │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │98  │98        │b_98                                    │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │99  │99        │b_99                                    │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │100 │100       │b_100                                   │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │101 │101       │b_101                                   │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │102 │102       │b_102                                   │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │103 │103       │b_103                                   │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │104 │104       │b_104                                   │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │105 │105       │b_105                                   │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │106 │106       │b_106                                   │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │107 │107       │b_107                                   │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │108 │108       │b_108                                   │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │109 │109       │b_109                                   │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │110 │110       │b_110                                   │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │111 │111       │b_111                                   │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │112 │112       │b_112                                   │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │113 │113       │b_113                                   │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │114 │114       │b_114                                   │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │115 │115       │b_115                                   │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │116 │116       │b_116                                   │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │117 │117       │b_117                                   │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │118 │118       │b_118                                   │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │119 │119       │b_119                                   │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │120 │120       │b_120                                   │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │121 │121       │b_121                                   │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │122 │122       │b_122                                   │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │123 │123       │b_123                                   │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │124 │124       │b_124                                   │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │125 │125       │b_125                                   │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │126 │126       │b_126                                   │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │127 │127       │b_127                                   │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │128 │128       │b_128                                   │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │129 │129       │b_129                                   │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │130 │130       │b_130                                   │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │131 │131       │b_131                                   │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │132 │132       │b_132                                   │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │133 │133       │b_133                                   │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │134 │134       │b_134                                   │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │135 │135       │b_135                                   │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │136 │136       │b_136                                   │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │137 │137       │b_137                                   │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │138 │138       │b_138                                   │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │139 │139       │b_139                                   │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │140 │140       │b_140                                   │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │141 │141       │b_141                                   │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │142 │142       │b_142                                   │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │143 │143       │b_143                                   │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │144 │144       │b_144                                   │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │145 │145       │b_145                                   │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │146 │146       │b_146                                   │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │147 │147       │b_147                                   │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │148 │148       │b_148                                   │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │149 │149       │b_149                                   │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │150 │150       │b_150                                   │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │151 │151       │b_151                                   │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │152 │152       │b_152                                   │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │153 │153       │b_153                                   │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │154 │154       │b_154                                   │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │155 │155       │b_155                                   │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │0.90 1.10                               │
+[ParameterHandlerGeneric.cpp][info] │156 │156       │b_156                                   │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │157 │157       │b_157                                   │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │158 │158       │b_158                                   │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │159 │159       │b_159                                   │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │160 │160       │b_160                                   │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │161 │161       │b_161                                   │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │162 │162       │b_162                                   │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │163 │163       │b_163                                   │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │164 │164       │b_164                                   │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │165 │165       │b_165                                   │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │166 │166       │b_166                                   │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │167 │167       │b_167                                   │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │168 │168       │b_168                                   │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │169 │169       │b_169                                   │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │170 │170       │b_170                                   │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │171 │171       │b_171                                   │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │172 │172       │b_172                                   │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │173 │173       │b_173                                   │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │174 │174       │b_174                                   │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │175 │175       │b_175                                   │TrueNeutrinoEnergy  │0.00 0.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │176 │176       │b_176                                   │TrueNeutrinoEnergy  │0.50 1.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │177 │177       │b_177                                   │TrueNeutrinoEnergy  │1.00 1.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │178 │178       │b_178                                   │TrueNeutrinoEnergy  │1.50 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │179 │179       │b_179                                   │TrueNeutrinoEnergy  │2.00 2.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │180 │180       │b_180                                   │TrueNeutrinoEnergy  │2.50 3.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │181 │181       │b_181                                   │TrueNeutrinoEnergy  │3.00 3.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │182 │182       │b_182                                   │TrueNeutrinoEnergy  │3.50 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │183 │183       │b_183                                   │TrueNeutrinoEnergy  │4.00 4.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │184 │184       │b_184                                   │TrueNeutrinoEnergy  │4.50 5.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │185 │185       │b_185                                   │TrueNeutrinoEnergy  │5.00 5.50                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │186 │186       │b_186                                   │TrueNeutrinoEnergy  │5.50 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │187 │187       │b_187                                   │TrueNeutrinoEnergy  │6.00 7.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │188 │188       │b_188                                   │TrueNeutrinoEnergy  │7.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │189 │189       │b_189                                   │TrueNeutrinoEnergy  │8.00 12.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │190 │190       │b_190                                   │TrueNeutrinoEnergy  │12.00 16.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │191 │191       │b_191                                   │TrueNeutrinoEnergy  │16.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │192 │192       │b_192                                   │TrueNeutrinoEnergy  │20.00 40.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │193 │193       │b_193                                   │TrueNeutrinoEnergy  │40.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │194 │194       │b_194                                   │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │195 │195       │b_195                                   │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │196 │196       │b_196                                   │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │197 │197       │b_197                                   │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │198 │198       │b_198                                   │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │199 │199       │b_199                                   │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │200 │200       │b_200                                   │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │201 │201       │b_201                                   │TrueNeutrinoEnergy  │0.00 2.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │202 │202       │b_202                                   │TrueNeutrinoEnergy  │2.00 4.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │203 │203       │b_203                                   │TrueNeutrinoEnergy  │4.00 6.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │204 │204       │b_204                                   │TrueNeutrinoEnergy  │6.00 8.00                               │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │205 │205       │b_205                                   │TrueNeutrinoEnergy  │8.00 10.00                              │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │206 │206       │b_206                                   │TrueNeutrinoEnergy  │10.00 20.00                             │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] │207 │207       │b_207                                   │TrueNeutrinoEnergy  │20.00 100.00                            │
+[ParameterHandlerGeneric.cpp][info] │    │          │                                        │IsFHC               │-0.10 0.10                              │
+[ParameterHandlerGeneric.cpp][info] └────┴──────────┴────────────────────────────────────────┴────────────────────┴────────────────────────────────────────┘
+[ParameterHandlerGeneric.cpp][info] Spline parameters: 55
+[ParameterHandlerGeneric.cpp][info] =====================================================================================================================================================================
+[ParameterHandlerGeneric.cpp][info] #    |  Name                                     |  Spline Name                              |  Spline Interpolation |  Low Knot Bound       |  Up Knot Bound        | 
+[ParameterHandlerGeneric.cpp][info] ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[ParameterHandlerGeneric.cpp][info] 0    |  MAQE                                     |  maqe                                     |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 1    |  CCQEPauliSupViaKF                        |  pauli                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 2    |  MaCCRES                                  |  mares                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 3    |  MvCCRES                                  |  mvres                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 4    |  MaNCRES                                  |  mancres                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 5    |  MvNCRES                                  |  mvncres                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 6    |  ThetaDelta2NPi                           |  thetadelta                               |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 7    |  AhtBY                                    |  ahtby                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 8    |  BhtBY                                    |  bhtby                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 9    |  CV1uBY                                   |  cv1uby                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 10   |  CV2uBY                                   |  cv2uby                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 11   |  FrCEx_pi                                 |  frcexpi                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 12   |  FrElas_pi                                |  frelaspi                                 |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 13   |  FrInel_pi                                |  frinelpi                                 |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 14   |  FrAbs_pi                                 |  frabspi                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 15   |  FrPiProd_pi                              |  frpiprodpi                               |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 16   |  FrCEx_N                                  |  frcexn                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 17   |  FrElas_N                                 |  frelasn                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 18   |  FrInel_N                                 |  frineln                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 19   |  FrAbs_N                                  |  frabsn                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 20   |  FrPiProd_N                               |  frpiprodn                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 21   |  E2p2h_A_nu                               |  e2anu                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 22   |  E2p2h_B_nu                               |  e2bnu                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 23   |  E2p2h_A_nubar                            |  e2anubar                                 |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 24   |  E2p2h_B_nubar                            |  e2bnubar                                 |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 25   |  C12ToAr40_2p2hScaling_nu                 |  c12nu                                    |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 26   |  C12ToAr40_2p2hScaling_nubar              |  c12nubar                                 |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 27   |  NR_nu_n_CC_2pi                           |  nuncc2                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 28   |  NR_nu_n_CC_3pi                           |  nuncc3                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 29   |  NR_nu_p_CC_2pi                           |  nupcc2                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 30   |  NR_nu_p_CC_3pi                           |  nupcc3                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 31   |  NR_nu_np_CC_1pi                          |  nunpcc1                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 32   |  NR_nu_n_NC_1pi                           |  nunnc1                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 33   |  NR_nu_n_NC_2pi                           |  nunnc2                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 34   |  NR_nu_n_NC_3pi                           |  nunnc3                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 35   |  NR_nu_p_NC_1pi                           |  nupnc1                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 36   |  NR_nu_p_NC_2pi                           |  nupnc2                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 37   |  NR_nu_p_NC_3pi                           |  nupnc3                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 38   |  NR_nubar_n_CC_1pi                        |  nubarncc1                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 39   |  NR_nubar_n_CC_2pi                        |  nubarncc2                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 40   |  NR_nubar_n_CC_3pi                        |  nubarncc3                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 41   |  NR_nubar_p_CC_1pi                        |  nubarpcc1                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 42   |  NR_nubar_p_CC_2pi                        |  nubarpcc2                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 43   |  NR_nubar_p_CC_3pi                        |  nubarpcc3                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 44   |  NR_nubar_n_NC_1pi                        |  nubarnnc1                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 45   |  NR_nubar_n_NC_2pi                        |  nubarnnc2                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 46   |  NR_nubar_n_NC_3pi                        |  nubarnnc3                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 47   |  NR_nubar_p_NC_1pi                        |  nubarpnc1                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 48   |  NR_nubar_p_NC_2pi                        |  nubarpnc2                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 49   |  NR_nubar_p_NC_3pi                        |  nubarpnc3                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 50   |  BeRPA_A                                  |  berpaa                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 51   |  BeRPA_B                                  |  berpab                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 52   |  BeRPA_D                                  |  berpad                                   |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 53   |  nuenuebar_xsec_ratio                     |  nuexsec                                  |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] 54   |  nuemumu_xsec_ratio                       |  nuemuxsec                                |  TSpline3             |  -9999                |  9999                 | 
+[ParameterHandlerGeneric.cpp][info] =====================================================================================================================================================================
+[ParameterHandlerGeneric.cpp][info] Functional parameters: 28
+[ParameterHandlerGeneric.cpp][info] ┌────┬──────────┬────────────────────────────────────────┐
+[ParameterHandlerGeneric.cpp][info] │#   │Global #  │Name                                    │
+[ParameterHandlerGeneric.cpp][info] ├────┼──────────┼────────────────────────────────────────┤
+[ParameterHandlerGeneric.cpp][info] │0   │263       │TotalEScaleFD                           │
+[ParameterHandlerGeneric.cpp][info] │1   │264       │TotalEScaleNotCCNumuFD                  │
+[ParameterHandlerGeneric.cpp][info] │2   │265       │TotalEScaleSqrtFD                       │
+[ParameterHandlerGeneric.cpp][info] │3   │266       │TotalEScaleSqrtNotCCNumuFD              │
+[ParameterHandlerGeneric.cpp][info] │4   │267       │TotalEScaleInvSqrtFD                    │
+[ParameterHandlerGeneric.cpp][info] │5   │268       │TotalEScaleInvSqrtNotCCNumuFD           │
+[ParameterHandlerGeneric.cpp][info] │6   │269       │HadEScaleFD                             │
+[ParameterHandlerGeneric.cpp][info] │7   │270       │HadEScaleSqrtFD                         │
+[ParameterHandlerGeneric.cpp][info] │8   │271       │HadEScaleInvSqrtFD                      │
+[ParameterHandlerGeneric.cpp][info] │9   │272       │MuEScaleFD                              │
+[ParameterHandlerGeneric.cpp][info] │10  │273       │MuEScaleSqrtFD                          │
+[ParameterHandlerGeneric.cpp][info] │11  │274       │MuEScaleInvSqrtFD                       │
+[ParameterHandlerGeneric.cpp][info] │12  │275       │NEScaleFD                               │
+[ParameterHandlerGeneric.cpp][info] │13  │276       │NEScaleSqrtFD                           │
+[ParameterHandlerGeneric.cpp][info] │14  │277       │NEScaleInvSqrtFD                        │
+[ParameterHandlerGeneric.cpp][info] │15  │278       │EMEScaleFD                              │
+[ParameterHandlerGeneric.cpp][info] │16  │279       │EMEScaleCCNueFD                         │
+[ParameterHandlerGeneric.cpp][info] │17  │280       │EMEScaleSqrtFD                          │
+[ParameterHandlerGeneric.cpp][info] │18  │281       │EMEScaleSqrtCCNueFD                     │
+[ParameterHandlerGeneric.cpp][info] │19  │282       │EMEScaleInvSqrtFD                       │
+[ParameterHandlerGeneric.cpp][info] │20  │283       │EMEScaleInvSqrtCCNueFD                  │
+[ParameterHandlerGeneric.cpp][info] │21  │284       │HadResFD                                │
+[ParameterHandlerGeneric.cpp][info] │22  │285       │MuResFD                                 │
+[ParameterHandlerGeneric.cpp][info] │23  │286       │NResFD                                  │
+[ParameterHandlerGeneric.cpp][info] │24  │287       │EMResFD                                 │
+[ParameterHandlerGeneric.cpp][info] │25  │288       │EMResCCNueFD                            │
+[ParameterHandlerGeneric.cpp][info] │26  │289       │RecoCVNNumuFD                           │
+[ParameterHandlerGeneric.cpp][info] │27  │290       │RecoCVNNueFD                            │
+[ParameterHandlerGeneric.cpp][info] └────┴──────────┴────────────────────────────────────────┘
+[ParameterHandlerGeneric.cpp][info] Oscillation parameters: 8
+[ParameterHandlerGeneric.cpp][info] ┌────┬──────────┬────────────────────────────────────────┐
+[ParameterHandlerGeneric.cpp][info] │#   │Global #  │Name                                    │
+[ParameterHandlerGeneric.cpp][info] ├────┼──────────┼────────────────────────────────────────┤
+[ParameterHandlerGeneric.cpp][info] │0   │293       │sin2th_12                               │
+[ParameterHandlerGeneric.cpp][info] │1   │294       │sin2th_23                               │
+[ParameterHandlerGeneric.cpp][info] │2   │295       │sin2th_13                               │
+[ParameterHandlerGeneric.cpp][info] │3   │296       │delm2_12                                │
+[ParameterHandlerGeneric.cpp][info] │4   │297       │delm2_23                                │
+[ParameterHandlerGeneric.cpp][info] │5   │298       │delta_cp                                │
+[ParameterHandlerGeneric.cpp][info] │6   │299       │baseline                                │
+[ParameterHandlerGeneric.cpp][info] │7   │300       │density                                 │
+[ParameterHandlerGeneric.cpp][info] └────┴──────────┴────────────────────────────────────────┘
+[ParameterHandlerGeneric.cpp][info] Printing parameter groups
+[ParameterHandlerGeneric.cpp][info] Found 30: DetSysts params
+[ParameterHandlerGeneric.cpp][info] Found 8: Osc params
+[ParameterHandlerGeneric.cpp][info] Found 55: Xsec params
+[ParameterHandlerGeneric.cpp][info] Found 208: Flux params
+[ParameterHandlerGeneric.cpp][info] Finished
+[ParameterHandlerGeneric.cpp][info] #################################################
+[ParameterHandlerBase.cpp][info] Setting baseline(parameter 299) to fixed at 1284.9
+[ParameterHandlerBase.cpp][info] Setting density(parameter 300) to fixed at 2.6
+[ParameterHandlerBase.cpp][info] xsec_cov setStepScale() = 0.05
+[MaCh3DUNEFactory.cpp][info] No SharedNuOscillatorObject for ATM found, so not creating one
+[MaCh3DUNEFactory.cpp][info] No SharedNuOscillatorObject for BeamFD found, so not creating one
+[MaCh3DUNEFactory.cpp][info] -------------------------------------------------------------------
+[MaCh3DUNEFactory.cpp][info] Loading DUNE samples..
+[Manager.cpp][info] Setting config to be: Configs/Samples/SampleHandler_FD_Beam.yaml
+[Manager.cpp][info] Config is now: 
+[Monitor.cpp][info] SampleHandlerName: BeamFD
+[Monitor.cpp][info] MaCh3ModeConfig: Configs/CovObjs/MaCh3Modes.yaml
+[Monitor.cpp][info] BinningFile: Configs/Samples/BeamParameterBinning.yaml
+[Monitor.cpp][info] InputFiles:
+[Monitor.cpp][info]   PrepSplineFile: false
+[Monitor.cpp][info] downsamplingStep: 10
+[Monitor.cpp][info] NuOsc:
+[Monitor.cpp][info]   NuOscConfigFile: Configs/NuOsc/CUDAProb3Linear.yaml
+[Monitor.cpp][info]   EqualBinningPerOscChannel: false
+[Monitor.cpp][info] Samples: [BeamFD_FHC_numu, BeamFD_FHC_nue, BeamFD_RHC_numu, BeamFD_RHC_nue]
+[Monitor.cpp][info] BeamFD_FHC_nue:
+[Monitor.cpp][info]   SampleName: BeamFD_FHC_nue
+[Monitor.cpp][info]   SampleTitle: BeamFD_FHC_nue
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNue
+[Monitor.cpp][info]       Bounds: [0.85, 999.]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: yes
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _nueselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _nueselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: FHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_FHC_numu:
+[Monitor.cpp][info]   SampleName: BeamFD_FHC_numu
+[Monitor.cpp][info]   SampleTitle: BeamFD_FHC_numu
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNumu
+[Monitor.cpp][info]       Bounds: [0.5, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _numuselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _numuselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: FHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_RHC_nue:
+[Monitor.cpp][info]   SampleName: BeamFD_RHC_nue
+[Monitor.cpp][info]   SampleTitle: BeamFD_RHC_nue
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNue
+[Monitor.cpp][info]       Bounds: [0.85, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: yes
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _nueselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _nueselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: RHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_RHC_numu:
+[Monitor.cpp][info]   SampleTitle: BeamFD_RHC_numu
+[Monitor.cpp][info]   SampleName: BeamFD_RHC_numu
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNumu
+[Monitor.cpp][info]       Bounds: [0.5, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _numuselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _numuselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: RHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] Creating SampleHandlerBase object
+[Manager.cpp][info] Setting config to be: Configs/Samples/SampleHandler_FD_Beam.yaml
+[Manager.cpp][info] Config is now: 
+[Monitor.cpp][info] SampleHandlerName: BeamFD
+[Monitor.cpp][info] MaCh3ModeConfig: Configs/CovObjs/MaCh3Modes.yaml
+[Monitor.cpp][info] BinningFile: Configs/Samples/BeamParameterBinning.yaml
+[Monitor.cpp][info] InputFiles:
+[Monitor.cpp][info]   PrepSplineFile: false
+[Monitor.cpp][info] downsamplingStep: 10
+[Monitor.cpp][info] NuOsc:
+[Monitor.cpp][info]   NuOscConfigFile: Configs/NuOsc/CUDAProb3Linear.yaml
+[Monitor.cpp][info]   EqualBinningPerOscChannel: false
+[Monitor.cpp][info] Samples: [BeamFD_FHC_numu, BeamFD_FHC_nue, BeamFD_RHC_numu, BeamFD_RHC_nue]
+[Monitor.cpp][info] BeamFD_FHC_nue:
+[Monitor.cpp][info]   SampleName: BeamFD_FHC_nue
+[Monitor.cpp][info]   SampleTitle: BeamFD_FHC_nue
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNue
+[Monitor.cpp][info]       Bounds: [0.85, 999.]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: yes
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _nueselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _nueselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: FHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_FHC_numu:
+[Monitor.cpp][info]   SampleName: BeamFD_FHC_numu
+[Monitor.cpp][info]   SampleTitle: BeamFD_FHC_numu
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNumu
+[Monitor.cpp][info]       Bounds: [0.5, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _numuselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _numuselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: FHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: FHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_RHC_nue:
+[Monitor.cpp][info]   SampleName: BeamFD_RHC_nue
+[Monitor.cpp][info]   SampleTitle: BeamFD_RHC_nue
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNue
+[Monitor.cpp][info]       Bounds: [0.85, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: yes
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _nueselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _nueselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: RHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info] BeamFD_RHC_numu:
+[Monitor.cpp][info]   SampleTitle: BeamFD_RHC_numu
+[Monitor.cpp][info]   SampleName: BeamFD_RHC_numu
+[Monitor.cpp][info]   POT: 1.3628319e+23
+[Monitor.cpp][info]   SelectionCuts:
+[Monitor.cpp][info]     - KinematicStr: TrueXPos
+[Monitor.cpp][info]       Bounds: [-310.0, 310.0]
+[Monitor.cpp][info]     - KinematicStr: TrueYPos
+[Monitor.cpp][info]       Bounds: [-550.0, 550.0]
+[Monitor.cpp][info]     - KinematicStr: TrueZPos
+[Monitor.cpp][info]       Bounds: [50.0, 1244.0]
+[Monitor.cpp][info]     - KinematicStr: CVNNumu
+[Monitor.cpp][info]       Bounds: [0.5, 999]
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: RecoNeutrinoEnergy
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]     BinEdges: [0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.]
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_CAF_files/FD_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _numuselec.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_spline_files/FD_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _numuselec_splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_numu_x_nue
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nue
+[Monitor.cpp][info]       mtuplefile: [numu_x_nue]
+[Monitor.cpp][info]       splinefile: numu_x_nue
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nuebar]
+[Monitor.cpp][info]       splinefile: numubar_x_nuebar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info]     - Name: RHC_nue_x_numu
+[Monitor.cpp][info]       LatexName: RHC_nue_x_numu
+[Monitor.cpp][info]       mtuplefile: [nue_x_numu]
+[Monitor.cpp][info]       splinefile: nue_x_numu
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_numubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_numubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_numu_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_numu_x_nutau
+[Monitor.cpp][info]       mtuplefile: [numu_x_nutau]
+[Monitor.cpp][info]       splinefile: numu_x_nutau
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_nue_x_nutau
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nutau
+[Monitor.cpp][info]       mtuplefile: [nue_x_nutau]
+[Monitor.cpp][info]       splinefile: nue_x_nutau
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 16
+[Monitor.cpp][info]     - Name: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: numubar_x_nutaubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -16
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nutaubar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nutaubar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nutaubar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -16
+[MaCh3Modes.cpp][info] Printing MaCh3 Modes Called: DUNE Interaction modes
+[MaCh3Modes.cpp][info] ========================================================================
+[MaCh3Modes.cpp][info] #     |  Name                 |  FancyName            |  SIMB Modes                    
+[MaCh3Modes.cpp][info] ------------------------------------------------------------------------
+[MaCh3Modes.cpp][info] 0     |  CCQE                 |  CCQE                 |  0                             
+[MaCh3Modes.cpp][info] 1     |  CC1Kaon              |  CC1Kaon              |  40                            
+[MaCh3Modes.cpp][info] 2     |  CCDIS                |  CCDIS                |  2                             
+[MaCh3Modes.cpp][info] 3     |  CCRES                |  CCRES                |  1                             
+[MaCh3Modes.cpp][info] 4     |  CCCOH                |  CCCOH                |  3                             
+[MaCh3Modes.cpp][info] 5     |  CCDiff               |  CCDiff               |  11                            
+[MaCh3Modes.cpp][info] 6     |  CCNuEl               |  CCNuEl               |  5                             
+[MaCh3Modes.cpp][info] 7     |  CCIMD                |  CCIMD                |  41                            
+[MaCh3Modes.cpp][info] 8     |  CCAnuGam             |  CCAnuGam             |  9                             
+[MaCh3Modes.cpp][info] 9     |  CCMEC                |  CCMEC                |  10                            
+[MaCh3Modes.cpp][info] 10    |  CCCOHEL              |  CCCOHEL              |  4                             
+[MaCh3Modes.cpp][info] 11    |  CCIBD                |  CCIBD                |  7                             
+[MaCh3Modes.cpp][info] 12    |  CCGlRES              |  CCGlRES              |  8                             
+[MaCh3Modes.cpp][info] 13    |  CCIMDAnn             |  CCIMDAnn             |  6                             
+[MaCh3Modes.cpp][info] 14    |  NCQE                 |  NCQE                 |  12                            
+[MaCh3Modes.cpp][info] 15    |  NCDIS                |  NCDIS                |  14                            
+[MaCh3Modes.cpp][info] 16    |  NCRES                |  NCRES                |  13                            
+[MaCh3Modes.cpp][info] 17    |  NCCOH                |  NCCOH                |  15                            
+[MaCh3Modes.cpp][info] 18    |  NCDiff               |  NCDiff               |  23                            
+[MaCh3Modes.cpp][info] 19    |  NCNuEl               |  NCNuEl               |  17                            
+[MaCh3Modes.cpp][info] 20    |  NCIMD                |  NCIMD                |  43                            
+[MaCh3Modes.cpp][info] 21    |  NCAnuGam             |  NCAnuGam             |  21                            
+[MaCh3Modes.cpp][info] 22    |  NCMEC                |  NCMEC                |  22                            
+[MaCh3Modes.cpp][info] 23    |  NCCOHEL              |  NCCOHEL              |  16                            
+[MaCh3Modes.cpp][info] 24    |  NCIBD                |  NCIBD                |  19                            
+[MaCh3Modes.cpp][info] 25    |  NCGlRES              |  NCGlRES              |  20                            
+[MaCh3Modes.cpp][info] 26    |  NCIMDAnn             |  NCIMDAnn             |  18                            
+[MaCh3Modes.cpp][info] ========================================================================
+[MaCh3Modes.cpp][info] ==========================
+[MaCh3Modes.cpp][info] SIMB Modes |  Name                          
+[MaCh3Modes.cpp][info] --------------------------
+[MaCh3Modes.cpp][info] 0          |  CCQE                          
+[MaCh3Modes.cpp][info] 1          |  CCRES                         
+[MaCh3Modes.cpp][info] 2          |  CCDIS                         
+[MaCh3Modes.cpp][info] 3          |  CCCOH                         
+[MaCh3Modes.cpp][info] 4          |  CCCOHEL                       
+[MaCh3Modes.cpp][info] 5          |  CCNuEl                        
+[MaCh3Modes.cpp][info] 6          |  CCIMDAnn                      
+[MaCh3Modes.cpp][info] 7          |  CCIBD                         
+[MaCh3Modes.cpp][info] 8          |  CCGlRES                       
+[MaCh3Modes.cpp][info] 9          |  CCAnuGam                      
+[MaCh3Modes.cpp][info] 10         |  CCMEC                         
+[MaCh3Modes.cpp][info] 11         |  CCDiff                        
+[MaCh3Modes.cpp][info] 12         |  NCQE                          
+[MaCh3Modes.cpp][info] 13         |  NCRES                         
+[MaCh3Modes.cpp][info] 14         |  NCDIS                         
+[MaCh3Modes.cpp][info] 15         |  NCCOH                         
+[MaCh3Modes.cpp][info] 16         |  NCCOHEL                       
+[MaCh3Modes.cpp][info] 17         |  NCNuEl                        
+[MaCh3Modes.cpp][info] 18         |  NCIMDAnn                      
+[MaCh3Modes.cpp][info] 19         |  NCIBD                         
+[MaCh3Modes.cpp][info] 20         |  NCGlRES                       
+[MaCh3Modes.cpp][info] 21         |  NCAnuGam                      
+[MaCh3Modes.cpp][info] 22         |  NCMEC                         
+[MaCh3Modes.cpp][info] 23         |  NCDiff                        
+[MaCh3Modes.cpp][info] 24         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 25         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 26         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 27         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 28         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 29         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 30         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 31         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 32         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 33         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 34         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 35         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 36         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 37         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 38         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 39         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 40         |  CC1Kaon                       
+[MaCh3Modes.cpp][info] 41         |  CCIMD                         
+[MaCh3Modes.cpp][info] 42         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 43         |  NCIMD                         
+[MaCh3Modes.cpp][info] ==========================
+[Manager.cpp][warning] Didn't find a TestStatistic specified
+[Manager.cpp][warning] Defaulting to using a Poisson likelihood
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleHandlerBase.cpp][info] Adding cut on TrueXPos with bounds -310 to 310
+[SampleHandlerBase.cpp][info] Adding cut on TrueYPos with bounds -550 to 550
+[SampleHandlerBase.cpp][info] Adding cut on TrueZPos with bounds 50 to 1244
+[SampleHandlerBase.cpp][info] Adding cut on CVNNumu with bounds 0.5 to 999
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleHandlerBase.cpp][info] Adding cut on TrueXPos with bounds -310 to 310
+[SampleHandlerBase.cpp][info] Adding cut on TrueYPos with bounds -550 to 550
+[SampleHandlerBase.cpp][info] Adding cut on TrueZPos with bounds 50 to 1244
+[SampleHandlerBase.cpp][info] Adding cut on CVNNue with bounds 0.85 to 999
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleHandlerBase.cpp][info] Adding cut on TrueXPos with bounds -310 to 310
+[SampleHandlerBase.cpp][info] Adding cut on TrueYPos with bounds -550 to 550
+[SampleHandlerBase.cpp][info] Adding cut on TrueZPos with bounds 50 to 1244
+[SampleHandlerBase.cpp][info] Adding cut on CVNNumu with bounds 0.5 to 999
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleHandlerBase.cpp][info] Adding cut on TrueXPos with bounds -310 to 310
+[SampleHandlerBase.cpp][info] Adding cut on TrueYPos with bounds -550 to 550
+[SampleHandlerBase.cpp][info] Adding cut on TrueZPos with bounds 50 to 1244
+[SampleHandlerBase.cpp][info] Adding cut on CVNNue with bounds 0.85 to 999
+[SampleHandlerBase.cpp][info]   Nominal mode weights to apply: 
+[SampleHandlerBase.cpp][info]     - CCQE: 1
+[SampleHandlerBase.cpp][info]     - CC1Kaon: 1
+[SampleHandlerBase.cpp][info]     - CCDIS: 1
+[SampleHandlerBase.cpp][info]     - CCRES: 1
+[SampleHandlerBase.cpp][info]     - CCCOH: 1
+[SampleHandlerBase.cpp][info]     - CCDiff: 1
+[SampleHandlerBase.cpp][info]     - CCNuEl: 1
+[SampleHandlerBase.cpp][info]     - CCIMD: 1
+[SampleHandlerBase.cpp][info]     - CCAnuGam: 1
+[SampleHandlerBase.cpp][info]     - CCMEC: 1
+[SampleHandlerBase.cpp][info]     - CCCOHEL: 1
+[SampleHandlerBase.cpp][info]     - CCIBD: 1
+[SampleHandlerBase.cpp][info]     - CCGlRES: 1
+[SampleHandlerBase.cpp][info]     - CCIMDAnn: 1
+[SampleHandlerBase.cpp][info]     - NCQE: 1
+[SampleHandlerBase.cpp][info]     - NCDIS: 1
+[SampleHandlerBase.cpp][info]     - NCRES: 1
+[SampleHandlerBase.cpp][info]     - NCCOH: 1
+[SampleHandlerBase.cpp][info]     - NCDiff: 1
+[SampleHandlerBase.cpp][info]     - NCNuEl: 1
+[SampleHandlerBase.cpp][info]     - NCIMD: 1
+[SampleHandlerBase.cpp][info]     - NCAnuGam: 1
+[SampleHandlerBase.cpp][info]     - NCMEC: 1
+[SampleHandlerBase.cpp][info]     - NCCOHEL: 1
+[SampleHandlerBase.cpp][info]     - NCIBD: 1
+[SampleHandlerBase.cpp][info]     - NCGlRES: 1
+[SampleHandlerBase.cpp][info]     - NCIMDAnn: 1
+[SampleHandlerBeamFD.cpp][info] Setting up beam sample BeamFD_FHC_numu
+[SampleHandlerBeamFD.cpp][info] - isFHC: 1
+[SampleHandlerBeamFD.cpp][info] - iselike: false
+[SampleHandlerBeamFD.cpp][info] Setting up beam sample BeamFD_FHC_nue
+[SampleHandlerBeamFD.cpp][info] - isFHC: 1
+[SampleHandlerBeamFD.cpp][info] - iselike: true
+[SampleHandlerBeamFD.cpp][info] Setting up beam sample BeamFD_RHC_numu
+[SampleHandlerBeamFD.cpp][info] - isFHC: 0
+[SampleHandlerBeamFD.cpp][info] - iselike: false
+[SampleHandlerBeamFD.cpp][info] Setting up beam sample BeamFD_RHC_nue
+[SampleHandlerBeamFD.cpp][info] - isFHC: 0
+[SampleHandlerBeamFD.cpp][info] - iselike: true
+[SampleHandlerBeamFD.cpp][info] Beam FD downsampling step: 10
+[SampleHandlerBeamFD.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBeamFD.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_numu_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_nue_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_numubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_nuebar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_nue_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_nuebar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_numu_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_numubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_nutau_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_nutau_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_nutaubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_nutaubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_numu_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_nue_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_numubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_nuebar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_nue_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_nuebar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_numu_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_numubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numu_x_nutau_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nue_x_nutau_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_numubar_x_nutaubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_FHC_ger_nuebar_x_nutaubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_numu_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_nue_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_numubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_nuebar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_nue_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_nuebar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_numu_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_numubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_nutau_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_nutau_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_nutaubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_nutaubar_numuselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_numu_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_nue_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_numubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_nuebar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_nue_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_nuebar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_numu_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_numubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numu_x_nutau_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nue_x_nutau_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_numubar_x_nutaubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Adding file to TChain: Inputs/DUNE_CAF_files/FD_RHC_ger_nuebar_x_nutaubar_nueselec.root
+[SampleHandlerBeamFD.cpp][info] Number of entries in TChain: 2673809
+[Monitor.cpp][info] [>                   ]   0/267380 (0%)
+[Monitor.cpp][info] [====>               ] 53476/267380 (20%)
+[Monitor.cpp][info] [========>           ] 106952/267380 (40%)
+[Monitor.cpp][info] [============>       ] 160428/267380 (60%)
+[Monitor.cpp][info] [================>   ] 213904/267380 (80%)
+[SampleHandlerBeamFD.cpp][warning] Found 332 negative values for rw_sum_ehad.
+[SampleHandlerBeamFD.cpp][warning] Found 53 negative values for rw_eRecoPi0.
+[SampleHandlerBeamFD.cpp][warning] Found 283 negative values for rw_eRecoN.
+[SampleHandlerBeamFD.cpp][warning] Found 623 negative values for rw_erec_had.
+[SampleHandlerBase.cpp][info] =============================================
+[SampleHandlerBase.cpp][info] Total number of events is: 267380
+[SampleHandlerBase.cpp][info] Setting up NuOscillator..
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 0/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 1/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 2/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 3/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 4/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 5/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 6/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 7/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 8/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 9/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 10/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 11/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 0/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 1/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 2/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 3/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 4/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 5/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 6/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 7/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 8/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 9/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 10/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 11/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 0/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 1/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 2/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 3/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 4/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 5/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 6/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 7/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 8/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 9/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 10/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 11/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 0/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 1/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 2/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 3/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 4/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 5/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 6/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 7/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 8/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 9/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 10/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[OscillationHandler.cpp][info] Setting up NuOscillator::Oscillator object in OscillationChannel: 11/12
+[OscillationHandler.cpp][info] [NuOscillator] OscillatorFactory creating OscillatorBase object from config: Configs/NuOsc/CUDAProb3Linear.yaml
+[SampleHandlerBase.cpp][info] Setting up Sample Binning..
+[SampleHandlerBase.cpp][info] Setting up Splines..
+[SampleHandlerBeamFD.cpp][info] Found 55 splines for this sample so I will create a spline object
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 55
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 1
+[BinnedSplineHandler.cpp][info] Details about sample: BeamFD_FHC_numu     
+[BinnedSplineHandler.cpp][info] 	 Dimension: 2                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 55                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 12                                 
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamFD_FHC_numu has 12 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 4 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 5 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 6 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 7 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 8 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 9 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 10 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 11 has 55 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 4	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 5	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 6	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 7	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 8	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 9	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 10	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 11	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 55
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 2
+[BinnedSplineHandler.cpp][info] Details about sample: BeamFD_FHC_nue      
+[BinnedSplineHandler.cpp][info] 	 Dimension: 2                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 55                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 12                                 
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamFD_FHC_nue has 12 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 4 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 5 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 6 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 7 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 8 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 9 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 10 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 11 has 55 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 4	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 5	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 6	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 7	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 8	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 9	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 10	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 11	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numu_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nue_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_numubar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_FHC_ger_nuebar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 55
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 3
+[BinnedSplineHandler.cpp][info] Details about sample: BeamFD_RHC_numu     
+[BinnedSplineHandler.cpp][info] 	 Dimension: 2                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 55                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 12                                 
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamFD_RHC_numu has 12 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 4 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 5 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 6 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 7 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 8 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 9 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 10 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 11 has 55 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 4	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 5	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 6	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 7	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 8	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 9	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 10	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 11	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nue_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nuebar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_numu_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_numubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nutau_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nutaubar_numuselec_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 55
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 4
+[BinnedSplineHandler.cpp][info] Details about sample: BeamFD_RHC_nue      
+[BinnedSplineHandler.cpp][info] 	 Dimension: 2                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 55                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 12                                 
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] 0 0.5 1 1.1 1.2 1.3 1.4 1.5 1.6 1.8 2 2.2 2.4 2.5 2.6 2.7 2.8 3 3.5 4 5 6 8 10 50 120 
+[BinnedSplineHandler.cpp][info] -1000000000000000 1000000000000000 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamFD_RHC_nue has 12 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 4 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 5 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 6 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 7 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 8 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 9 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 10 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 11 has 55 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 4	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 5	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 6	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 7	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 8	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 9	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 10	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 11	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nue_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nuebar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_numu_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_numubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numu_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nue_x_nutau_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_numubar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_spline_files/FD_RHC_ger_nuebar_x_nutaubar_nueselec_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Total number of splines loaded: 3420000
+[BinnedSplineHandler.cpp][info] Total number of non-flat splines loaded: 266110
+[BinnedSplineHandler.cpp][info] nUniqueSysts: 55
+[BinnedSplineHandler.cpp][info] Spline Index    | Syst Name            | nKnots
+[BinnedSplineHandler.cpp][info] 0               | maqe                 | 7     
+[BinnedSplineHandler.cpp][info] 1               | pauli                | 2     
+[BinnedSplineHandler.cpp][info] 2               | mares                | 8     
+[BinnedSplineHandler.cpp][info] 3               | mvres                | 7     
+[BinnedSplineHandler.cpp][info] 4               | mancres              | 7     
+[BinnedSplineHandler.cpp][info] 5               | mvncres              | 7     
+[BinnedSplineHandler.cpp][info] 6               | thetadelta           | 2     
+[BinnedSplineHandler.cpp][info] 7               | ahtby                | 7     
+[BinnedSplineHandler.cpp][info] 8               | bhtby                | 7     
+[BinnedSplineHandler.cpp][info] 9               | cv1uby               | 7     
+[BinnedSplineHandler.cpp][info] 10              | cv2uby               | 7     
+[BinnedSplineHandler.cpp][info] 11              | frcexpi              | 7     
+[BinnedSplineHandler.cpp][info] 12              | frelaspi             | 7     
+[BinnedSplineHandler.cpp][info] 13              | frinelpi             | 7     
+[BinnedSplineHandler.cpp][info] 14              | frabspi              | 7     
+[BinnedSplineHandler.cpp][info] 15              | frpiprodpi           | 7     
+[BinnedSplineHandler.cpp][info] 16              | frcexn               | 7     
+[BinnedSplineHandler.cpp][info] 17              | frelasn              | 7     
+[BinnedSplineHandler.cpp][info] 18              | frineln              | 7     
+[BinnedSplineHandler.cpp][info] 19              | frabsn               | 7     
+[BinnedSplineHandler.cpp][info] 20              | frpiprodn            | 7     
+[BinnedSplineHandler.cpp][info] 21              | e2anu                | 5     
+[BinnedSplineHandler.cpp][info] 22              | e2bnu                | 5     
+[BinnedSplineHandler.cpp][info] 23              | e2anubar             | 5     
+[BinnedSplineHandler.cpp][info] 24              | e2bnubar             | 5     
+[BinnedSplineHandler.cpp][info] 25              | c12nu                | 2     
+[BinnedSplineHandler.cpp][info] 26              | c12nubar             | 2     
+[BinnedSplineHandler.cpp][info] 27              | nuncc2               | 6     
+[BinnedSplineHandler.cpp][info] 28              | nuncc3               | 6     
+[BinnedSplineHandler.cpp][info] 29              | nupcc2               | 6     
+[BinnedSplineHandler.cpp][info] 30              | nupcc3               | 6     
+[BinnedSplineHandler.cpp][info] 31              | nunpcc1              | 8     
+[BinnedSplineHandler.cpp][info] 32              | nunnc1               | 6     
+[BinnedSplineHandler.cpp][info] 33              | nunnc2               | 6     
+[BinnedSplineHandler.cpp][info] 34              | nunnc3               | 6     
+[BinnedSplineHandler.cpp][info] 35              | nupnc1               | 6     
+[BinnedSplineHandler.cpp][info] 36              | nupnc2               | 6     
+[BinnedSplineHandler.cpp][info] 37              | nupnc3               | 6     
+[BinnedSplineHandler.cpp][info] 38              | nubarncc1            | 6     
+[BinnedSplineHandler.cpp][info] 39              | nubarncc2            | 6     
+[BinnedSplineHandler.cpp][info] 40              | nubarncc3            | 6     
+[BinnedSplineHandler.cpp][info] 41              | nubarpcc1            | 6     
+[BinnedSplineHandler.cpp][info] 42              | nubarpcc2            | 6     
+[BinnedSplineHandler.cpp][info] 43              | nubarpcc3            | 6     
+[BinnedSplineHandler.cpp][info] 44              | nubarnnc1            | 6     
+[BinnedSplineHandler.cpp][info] 45              | nubarnnc2            | 6     
+[BinnedSplineHandler.cpp][info] 46              | nubarnnc3            | 6     
+[BinnedSplineHandler.cpp][info] 47              | nubarpnc1            | 6     
+[BinnedSplineHandler.cpp][info] 48              | nubarpnc2            | 6     
+[BinnedSplineHandler.cpp][info] 49              | nubarpnc3            | 6     
+[BinnedSplineHandler.cpp][info] 50              | berpaa               | 7     
+[BinnedSplineHandler.cpp][info] 51              | berpab               | 7     
+[BinnedSplineHandler.cpp][info] 52              | berpad               | 7     
+[BinnedSplineHandler.cpp][info] 53              | nuexsec              | 2     
+[BinnedSplineHandler.cpp][info] 54              | nuemuxsec            | 2     
+[BinnedSplineHandler.cpp][info] Number of combinations of Sample, OscChan, Syst and Mode which have entirely flat response: 3153890 / 3420000
+[BinnedSplineHandler.cpp][info] Total number of splines loaded: 3420000
+[BinnedSplineHandler.cpp][info] Total number of non-flat splines loaded: 266110
+[BinnedSplineHandler.cpp][info] Now transferring splines to a monolith if size 3420000
+[SampleHandlerBase.cpp][info] --------------------------------
+[SampleHandlerBase.cpp][info] Setup Far Detector splines
+[BinnedSplineHandler.cpp][info] Cleaning up spline memory
+[SampleHandlerBase.cpp][info] Setting up Normalisation Pointers..
+[SampleHandlerBase.cpp][info] Setting up Functional Pointers..
+[SampleHandlerBeamFD.cpp][info] Registering functional parameters
+[SampleHandlerBeamFD.cpp][info] Finished registering functional parameters
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleFD to funcParsMap with key: 0
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtFD to funcParsMap with key: 2
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtFD to funcParsMap with key: 4
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleFD to funcParsMap with key: 6
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleSqrtFD to funcParsMap with key: 7
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleInvSqrtFD to funcParsMap with key: 8
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleFD to funcParsMap with key: 9
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleSqrtFD to funcParsMap with key: 10
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleInvSqrtFD to funcParsMap with key: 11
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleFD to funcParsMap with key: 12
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleSqrtFD to funcParsMap with key: 13
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleInvSqrtFD to funcParsMap with key: 14
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleFD to funcParsMap with key: 15
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtFD to funcParsMap with key: 17
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtFD to funcParsMap with key: 19
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadResFD to funcParsMap with key: 21
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuResFD to funcParsMap with key: 22
+[SampleHandlerBase.cpp][info] Adding functional parameter: NResFD to funcParsMap with key: 23
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResFD to funcParsMap with key: 24
+[SampleHandlerBase.cpp][info] Adding functional parameter: RecoCVNNumuFD to funcParsMap with key: 26
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleFD to funcParsMap with key: 0
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleNotCCNumuFD to funcParsMap with key: 1
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtFD to funcParsMap with key: 2
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtNotCCNumuFD to funcParsMap with key: 3
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtFD to funcParsMap with key: 4
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtNotCCNumuFD to funcParsMap with key: 5
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleFD to funcParsMap with key: 6
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleSqrtFD to funcParsMap with key: 7
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleInvSqrtFD to funcParsMap with key: 8
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleFD to funcParsMap with key: 12
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleSqrtFD to funcParsMap with key: 13
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleInvSqrtFD to funcParsMap with key: 14
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleFD to funcParsMap with key: 15
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleCCNueFD to funcParsMap with key: 16
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtFD to funcParsMap with key: 17
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtCCNueFD to funcParsMap with key: 18
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtFD to funcParsMap with key: 19
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtCCNueFD to funcParsMap with key: 20
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadResFD to funcParsMap with key: 21
+[SampleHandlerBase.cpp][info] Adding functional parameter: NResFD to funcParsMap with key: 23
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResFD to funcParsMap with key: 24
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResCCNueFD to funcParsMap with key: 25
+[SampleHandlerBase.cpp][info] Adding functional parameter: RecoCVNNueFD to funcParsMap with key: 27
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleFD to funcParsMap with key: 0
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtFD to funcParsMap with key: 2
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtFD to funcParsMap with key: 4
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleFD to funcParsMap with key: 6
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleSqrtFD to funcParsMap with key: 7
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleInvSqrtFD to funcParsMap with key: 8
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleFD to funcParsMap with key: 9
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleSqrtFD to funcParsMap with key: 10
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuEScaleInvSqrtFD to funcParsMap with key: 11
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleFD to funcParsMap with key: 12
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleSqrtFD to funcParsMap with key: 13
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleInvSqrtFD to funcParsMap with key: 14
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleFD to funcParsMap with key: 15
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtFD to funcParsMap with key: 17
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtFD to funcParsMap with key: 19
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadResFD to funcParsMap with key: 21
+[SampleHandlerBase.cpp][info] Adding functional parameter: MuResFD to funcParsMap with key: 22
+[SampleHandlerBase.cpp][info] Adding functional parameter: NResFD to funcParsMap with key: 23
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResFD to funcParsMap with key: 24
+[SampleHandlerBase.cpp][info] Adding functional parameter: RecoCVNNumuFD to funcParsMap with key: 26
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleFD to funcParsMap with key: 0
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleNotCCNumuFD to funcParsMap with key: 1
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtFD to funcParsMap with key: 2
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleSqrtNotCCNumuFD to funcParsMap with key: 3
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtFD to funcParsMap with key: 4
+[SampleHandlerBase.cpp][info] Adding functional parameter: TotalEScaleInvSqrtNotCCNumuFD to funcParsMap with key: 5
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleFD to funcParsMap with key: 6
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleSqrtFD to funcParsMap with key: 7
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadEScaleInvSqrtFD to funcParsMap with key: 8
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleFD to funcParsMap with key: 12
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleSqrtFD to funcParsMap with key: 13
+[SampleHandlerBase.cpp][info] Adding functional parameter: NEScaleInvSqrtFD to funcParsMap with key: 14
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleFD to funcParsMap with key: 15
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleCCNueFD to funcParsMap with key: 16
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtFD to funcParsMap with key: 17
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleSqrtCCNueFD to funcParsMap with key: 18
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtFD to funcParsMap with key: 19
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMEScaleInvSqrtCCNueFD to funcParsMap with key: 20
+[SampleHandlerBase.cpp][info] Adding functional parameter: HadResFD to funcParsMap with key: 21
+[SampleHandlerBase.cpp][info] Adding functional parameter: NResFD to funcParsMap with key: 23
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResFD to funcParsMap with key: 24
+[SampleHandlerBase.cpp][info] Adding functional parameter: EMResCCNueFD to funcParsMap with key: 25
+[SampleHandlerBase.cpp][info] Adding functional parameter: RecoCVNNueFD to funcParsMap with key: 27
+[SampleHandlerBase.cpp][info] Finished setting up functional parameters
+[SampleHandlerBase.cpp][info] Setting up Additional Weight Pointers..
+[SampleHandlerBase.cpp][info] Setting up Kinematic Map..
+[SampleHandlerBase.cpp][info] Finished loading MC for BeamFD, it took 84.47s to finish
+[SampleHandlerBase.cpp][info] Initialising Data
+[SampleHandlerBase.cpp][info] =======================================================
+[Manager.cpp][info] Setting config to be: Configs/Samples/SampleHandler_ND.yaml
+[Manager.cpp][info] Config is now: 
+[Monitor.cpp][info] SampleHandlerName: BeamND
+[Monitor.cpp][info] MaCh3ModeConfig: Configs/CovObjs/MaCh3Modes_GENIE.yaml
+[Monitor.cpp][info] BinningFile: Configs/Samples/BeamParameterBinning.yaml
+[Monitor.cpp][info] InputFiles:
+[Monitor.cpp][info]   PrepSplineFile: false
+[Monitor.cpp][info] downsamplingStep: 10
+[Monitor.cpp][info] Samples:
+[Monitor.cpp][info]   - BeamND_FHC_CCnumu
+[Monitor.cpp][info]   - BeamND_RHC_CCnumu
+[Monitor.cpp][info] BeamND_FHC_CCnumu:
+[Monitor.cpp][info]   SampleTitle: BeamND_FHC_CCnumu
+[Monitor.cpp][info]   SampleName: BeamND_FHC_CCnumu
+[Monitor.cpp][info]   POT: 3.85e21
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: [RecoNeutrinoEnergy, yRec]
+[Monitor.cpp][info]     VarBins: [[0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.], [0., 0.1, 0.2, 0.3, 0.4, 0.6, 1.1]]
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _fv_ccinc_q.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_ND_spline_files/ND_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu_*]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info] BeamND_RHC_CCnumu:
+[Monitor.cpp][info]   SampleTitle: BeamND_RHC_CCnumu
+[Monitor.cpp][info]   SampleName: BeamND_RHC_CCnumu
+[Monitor.cpp][info]   POT: 3.85e21
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: [RecoNeutrinoEnergy, yRec]
+[Monitor.cpp][info]     VarBins: [[0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.], [0., 0.1, 0.2, 0.3, 0.4, 0.6, 1.1]]
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _fv_ccinc_q.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_ND_spline_files/ND_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu_*]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar_*]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] Creating SampleHandlerBase object
+[Manager.cpp][info] Setting config to be: Configs/Samples/SampleHandler_ND.yaml
+[Manager.cpp][info] Config is now: 
+[Monitor.cpp][info] SampleHandlerName: BeamND
+[Monitor.cpp][info] MaCh3ModeConfig: Configs/CovObjs/MaCh3Modes_GENIE.yaml
+[Monitor.cpp][info] BinningFile: Configs/Samples/BeamParameterBinning.yaml
+[Monitor.cpp][info] InputFiles:
+[Monitor.cpp][info]   PrepSplineFile: false
+[Monitor.cpp][info] downsamplingStep: 10
+[Monitor.cpp][info] Samples:
+[Monitor.cpp][info]   - BeamND_FHC_CCnumu
+[Monitor.cpp][info]   - BeamND_RHC_CCnumu
+[Monitor.cpp][info] BeamND_FHC_CCnumu:
+[Monitor.cpp][info]   SampleTitle: BeamND_FHC_CCnumu
+[Monitor.cpp][info]   SampleName: BeamND_FHC_CCnumu
+[Monitor.cpp][info]   POT: 3.85e21
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: [RecoNeutrinoEnergy, yRec]
+[Monitor.cpp][info]     VarBins: [[0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.], [0., 0.1, 0.2, 0.3, 0.4, 0.6, 1.1]]
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     isFHC: 1
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _fv_ccinc_q.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_ND_spline_files/ND_FHC_ger_
+[Monitor.cpp][info]     splinesuffix: _splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: FHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: FHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu_*]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: FHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: FHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: FHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: FHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: FHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[Monitor.cpp][info] BeamND_RHC_CCnumu:
+[Monitor.cpp][info]   SampleTitle: BeamND_RHC_CCnumu
+[Monitor.cpp][info]   SampleName: BeamND_RHC_CCnumu
+[Monitor.cpp][info]   POT: 3.85e21
+[Monitor.cpp][info]   Binning:
+[Monitor.cpp][info]     VarStr: [RecoNeutrinoEnergy, yRec]
+[Monitor.cpp][info]     VarBins: [[0., 0.5, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 3.75, 4., 5., 6., 10.], [0., 0.1, 0.2, 0.3, 0.4, 0.6, 1.1]]
+[Monitor.cpp][info]     Uniform: true
+[Monitor.cpp][info]   DUNESampleBools:
+[Monitor.cpp][info]     isFHC: 0
+[Monitor.cpp][info]     iselike: no
+[Monitor.cpp][info]   InputFiles:
+[Monitor.cpp][info]     mtupleprefix: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_
+[Monitor.cpp][info]     mtuplesuffix: _fv_ccinc_q.root
+[Monitor.cpp][info]     splineprefix: Inputs/DUNE_ND_spline_files/ND_RHC_ger_
+[Monitor.cpp][info]     splinesuffix: _splines.root
+[Monitor.cpp][info]   OscChannels:
+[Monitor.cpp][info]     - Name: RHC_numu_x_numu
+[Monitor.cpp][info]       LatexName: RHC_numu_x_numu
+[Monitor.cpp][info]       mtuplefile: [numu_x_numu_*]
+[Monitor.cpp][info]       splinefile: numu_x_numu
+[Monitor.cpp][info]       nutype: 14
+[Monitor.cpp][info]       oscnutype: 14
+[Monitor.cpp][info]     - Name: RHC_nue_x_nue
+[Monitor.cpp][info]       LatexName: RHC_nue_x_nue
+[Monitor.cpp][info]       mtuplefile: [nue_x_nue]
+[Monitor.cpp][info]       splinefile: nue_x_nue
+[Monitor.cpp][info]       nutype: 12
+[Monitor.cpp][info]       oscnutype: 12
+[Monitor.cpp][info]     - Name: RHC_numubar_x_numubar
+[Monitor.cpp][info]       LatexName: RHC_numubar_x_numubar
+[Monitor.cpp][info]       mtuplefile: [numubar_x_numubar_*]
+[Monitor.cpp][info]       splinefile: numubar_x_numubar
+[Monitor.cpp][info]       nutype: -14
+[Monitor.cpp][info]       oscnutype: -14
+[Monitor.cpp][info]     - Name: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       LatexName: RHC_nuebar_x_nuebar
+[Monitor.cpp][info]       mtuplefile: [nuebar_x_nuebar]
+[Monitor.cpp][info]       splinefile: nuebar_x_nuebar
+[Monitor.cpp][info]       nutype: -12
+[Monitor.cpp][info]       oscnutype: -12
+[MaCh3Modes.cpp][info] Printing MaCh3 Modes Called: DUNE Interaction modes
+[MaCh3Modes.cpp][info] ========================================================================
+[MaCh3Modes.cpp][info] #     |  Name                 |  FancyName            |  GENIE Modes                   
+[MaCh3Modes.cpp][info] ------------------------------------------------------------------------
+[MaCh3Modes.cpp][info] 0     |  CCQE                 |  CCQE                 |  1                             
+[MaCh3Modes.cpp][info] 1     |  CC1Kaon              |  CC1Kaon              |  2                             
+[MaCh3Modes.cpp][info] 2     |  CCDIS                |  CCDIS                |  3                             
+[MaCh3Modes.cpp][info] 3     |  CCRES                |  CCRES                |  4                             
+[MaCh3Modes.cpp][info] 4     |  CCCOH                |  CCCOH                |  5                             
+[MaCh3Modes.cpp][info] 5     |  CCDiff               |  CCDiff               |  6                             
+[MaCh3Modes.cpp][info] 6     |  CCNuEl               |  CCNuEl               |  7                             
+[MaCh3Modes.cpp][info] 7     |  CCIMD                |  CCIMD                |  8                             
+[MaCh3Modes.cpp][info] 8     |  CCAnuGam             |  CCAnuGam             |  9                             
+[MaCh3Modes.cpp][info] 9     |  CCMEC                |  CCMEC                |  10                            
+[MaCh3Modes.cpp][info] 10    |  CCCOHEL              |  CCCOHEL              |  11                            
+[MaCh3Modes.cpp][info] 11    |  CCIBD                |  CCIBD                |  12                            
+[MaCh3Modes.cpp][info] 12    |  CCGlRES              |  CCGlRES              |  13                            
+[MaCh3Modes.cpp][info] 13    |  CCIMDAnn             |  CCIMDAnn             |  14                            
+[MaCh3Modes.cpp][info] 14    |  NCQE                 |  NCQE                 |  15                            
+[MaCh3Modes.cpp][info] 15    |  NCDIS                |  NCDIS                |  17                            
+[MaCh3Modes.cpp][info] 16    |  NCRES                |  NCRES                |  18                            
+[MaCh3Modes.cpp][info] 17    |  NCCOH                |  NCCOH                |  19                            
+[MaCh3Modes.cpp][info] 18    |  NCDiff               |  NCDiff               |  20                            
+[MaCh3Modes.cpp][info] 19    |  NCNuEl               |  NCNuEl               |  21                            
+[MaCh3Modes.cpp][info] 20    |  NCIMD                |  NCIMD                |  22                            
+[MaCh3Modes.cpp][info] 21    |  NCAnuGam             |  NCAnuGam             |  23                            
+[MaCh3Modes.cpp][info] 22    |  NCMEC                |  NCMEC                |  24                            
+[MaCh3Modes.cpp][info] 23    |  NCCOHEL              |  NCCOHEL              |  25                            
+[MaCh3Modes.cpp][info] 24    |  NCIBD                |  NCIBD                |  26                            
+[MaCh3Modes.cpp][info] 25    |  NCGlRES              |  NCGlRES              |  27                            
+[MaCh3Modes.cpp][info] 26    |  NCIMDAnn             |  NCIMDAnn             |  28                            
+[MaCh3Modes.cpp][info] ========================================================================
+[MaCh3Modes.cpp][info] ==========================
+[MaCh3Modes.cpp][info] GENIE Modes |  Name                          
+[MaCh3Modes.cpp][info] --------------------------
+[MaCh3Modes.cpp][info] 0          |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 1          |  CCQE                          
+[MaCh3Modes.cpp][info] 2          |  CC1Kaon                       
+[MaCh3Modes.cpp][info] 3          |  CCDIS                         
+[MaCh3Modes.cpp][info] 4          |  CCRES                         
+[MaCh3Modes.cpp][info] 5          |  CCCOH                         
+[MaCh3Modes.cpp][info] 6          |  CCDiff                        
+[MaCh3Modes.cpp][info] 7          |  CCNuEl                        
+[MaCh3Modes.cpp][info] 8          |  CCIMD                         
+[MaCh3Modes.cpp][info] 9          |  CCAnuGam                      
+[MaCh3Modes.cpp][info] 10         |  CCMEC                         
+[MaCh3Modes.cpp][info] 11         |  CCCOHEL                       
+[MaCh3Modes.cpp][info] 12         |  CCIBD                         
+[MaCh3Modes.cpp][info] 13         |  CCGlRES                       
+[MaCh3Modes.cpp][info] 14         |  CCIMDAnn                      
+[MaCh3Modes.cpp][info] 15         |  NCQE                          
+[MaCh3Modes.cpp][info] 16         |  UNKNOWN_BAD                   
+[MaCh3Modes.cpp][info] 17         |  NCDIS                         
+[MaCh3Modes.cpp][info] 18         |  NCRES                         
+[MaCh3Modes.cpp][info] 19         |  NCCOH                         
+[MaCh3Modes.cpp][info] 20         |  NCDiff                        
+[MaCh3Modes.cpp][info] 21         |  NCNuEl                        
+[MaCh3Modes.cpp][info] 22         |  NCIMD                         
+[MaCh3Modes.cpp][info] 23         |  NCAnuGam                      
+[MaCh3Modes.cpp][info] 24         |  NCMEC                         
+[MaCh3Modes.cpp][info] 25         |  NCCOHEL                       
+[MaCh3Modes.cpp][info] 26         |  NCIBD                         
+[MaCh3Modes.cpp][info] 27         |  NCGlRES                       
+[MaCh3Modes.cpp][info] 28         |  NCIMDAnn                      
+[MaCh3Modes.cpp][info] ==========================
+[Manager.cpp][warning] Didn't find a TestStatistic specified
+[Manager.cpp][warning] Defaulting to using a Poisson likelihood
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleStructs.h][info] 1-Dim Binning: [0.00, 0.10, 0.20, 0.30, 0.40, 0.60, 1.10]
+[BinningHandler.cpp][info] Setting up Sample Binning
+[SampleStructs.h][info] 0-Dim Binning: [0.00, 0.50, 1.00, 1.25, 1.50, 1.75, 2.00, 2.25, 2.50, 2.75, 3.00, 3.25, 3.50, 3.75, 4.00, 5.00, 6.00, 10.00]
+[SampleStructs.h][info] 1-Dim Binning: [0.00, 0.10, 0.20, 0.30, 0.40, 0.60, 1.10]
+[SampleHandlerBase.cpp][info]   Nominal mode weights to apply: 
+[SampleHandlerBase.cpp][info]     - CCQE: 1
+[SampleHandlerBase.cpp][info]     - CC1Kaon: 1
+[SampleHandlerBase.cpp][info]     - CCDIS: 1
+[SampleHandlerBase.cpp][info]     - CCRES: 1
+[SampleHandlerBase.cpp][info]     - CCCOH: 1
+[SampleHandlerBase.cpp][info]     - CCDiff: 1
+[SampleHandlerBase.cpp][info]     - CCNuEl: 1
+[SampleHandlerBase.cpp][info]     - CCIMD: 1
+[SampleHandlerBase.cpp][info]     - CCAnuGam: 1
+[SampleHandlerBase.cpp][info]     - CCMEC: 1
+[SampleHandlerBase.cpp][info]     - CCCOHEL: 1
+[SampleHandlerBase.cpp][info]     - CCIBD: 1
+[SampleHandlerBase.cpp][info]     - CCGlRES: 1
+[SampleHandlerBase.cpp][info]     - CCIMDAnn: 1
+[SampleHandlerBase.cpp][info]     - NCQE: 1
+[SampleHandlerBase.cpp][info]     - NCDIS: 1
+[SampleHandlerBase.cpp][info]     - NCRES: 1
+[SampleHandlerBase.cpp][info]     - NCCOH: 1
+[SampleHandlerBase.cpp][info]     - NCDiff: 1
+[SampleHandlerBase.cpp][info]     - NCNuEl: 1
+[SampleHandlerBase.cpp][info]     - NCIMD: 1
+[SampleHandlerBase.cpp][info]     - NCAnuGam: 1
+[SampleHandlerBase.cpp][info]     - NCMEC: 1
+[SampleHandlerBase.cpp][info]     - NCCOHEL: 1
+[SampleHandlerBase.cpp][info]     - NCIBD: 1
+[SampleHandlerBase.cpp][info]     - NCGlRES: 1
+[SampleHandlerBase.cpp][info]     - NCIMDAnn: 1
+[SampleHandlerBeamND.cpp][info] Setting up beam ND sample BeamND_FHC_CCnumu
+[SampleHandlerBeamND.cpp][info] - isFHC: 1
+[SampleHandlerBeamND.cpp][info] - iselike: false
+[SampleHandlerBeamND.cpp][info] Setting up beam ND sample BeamND_RHC_CCnumu
+[SampleHandlerBeamND.cpp][info] - isFHC: 0
+[SampleHandlerBeamND.cpp][info] - iselike: false
+[SampleHandlerBeamND.cpp][info] Beam ND downsampling step: 10
+[SampleHandlerBeamND.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBeamND.cpp][info] -------------------------------------------------------------------
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_numu_x_numu_*_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_nue_x_nue_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_numubar_x_numubar_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_FHC_ger_nuebar_x_nuebar_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_numu_x_numu_*_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_nue_x_nue_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_numubar_x_numubar_*_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Adding file to TChain: Inputs/DUNE_ND_CAF_files/ND_RHC_ger_nuebar_x_nuebar_fv_ccinc_q.root
+[SampleHandlerBeamND.cpp][info] Number of entries in TChain: 49480472
+[Monitor.cpp][info] [>                   ]   0/4948047 (0%)
+[Monitor.cpp][info] [=>                  ] 494804/4948047 (9%)
+[Monitor.cpp][info] [===>                ] 989608/4948047 (19%)
+[Monitor.cpp][info] [=====>              ] 1484412/4948047 (29%)
+[Monitor.cpp][info] [=======>            ] 1979216/4948047 (39%)
+[Monitor.cpp][info] [=========>          ] 2474020/4948047 (49%)
+[Monitor.cpp][info] [===========>        ] 2968824/4948047 (59%)
+[Monitor.cpp][info] [=============>      ] 3463628/4948047 (69%)
+[Monitor.cpp][info] [===============>    ] 3958432/4948047 (79%)
+[Monitor.cpp][info] [=================>  ] 4453236/4948047 (89%)
+[Monitor.cpp][info] [===================>] 4948040/4948047 (99%)
+[SampleHandlerBase.cpp][info] =============================================
+[SampleHandlerBase.cpp][info] Total number of events is: 4948047
+[SampleHandlerBase.cpp][warning] Didn't find any oscillation params, thus will not enable oscillations
+[SampleHandlerBase.cpp][info] Setting up Sample Binning..
+[SampleHandlerBase.cpp][info] Setting up Splines..
+[SampleHandlerBeamND.cpp][info] Found 54 splines for this sample so I will create a spline object
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 55
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 1
+[BinnedSplineHandler.cpp][info] Details about sample: BeamND_FHC_CCnumu   
+[BinnedSplineHandler.cpp][info] 	 Dimension: 3                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 55                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 4                                  
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_FHC_ger_numu_x_numu_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_FHC_ger_nue_x_nue_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_FHC_ger_numubar_x_numubar_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_FHC_ger_nuebar_x_nuebar_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamND_FHC_CCnumu has 4 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 55 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 55 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_FHC_ger_numu_x_numu_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_FHC_ger_nue_x_nue_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_FHC_ger_numubar_x_numubar_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_FHC_ger_nuebar_x_nuebar_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Create SplineModeVecs_Sample
+[BinnedSplineHandler.cpp][info] SplineModeVecs_Sample is of size 54
+[BinnedSplineHandler.cpp][info] SplineModeVecs is of size 2
+[BinnedSplineHandler.cpp][info] Details about sample: BeamND_RHC_CCnumu   
+[BinnedSplineHandler.cpp][info] 	 Dimension: 3                                  
+[BinnedSplineHandler.cpp][info] 	 nSplineParam: 54                                 
+[BinnedSplineHandler.cpp][info] 	 nOscChan: 4                                  
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_RHC_ger_numu_x_numu_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_RHC_ger_nue_x_nue_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_RHC_ger_numubar_x_numubar_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] Finding binning for:
+[BinnedSplineHandler.cpp][info] Inputs/DUNE_ND_spline_files/ND_RHC_ger_nuebar_x_nuebar_splines.root
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 1 1.5 2 2.5 3 3.5 4 10 
+[BinnedSplineHandler.cpp][info] 0 0.1 0.2 0.3 0.4 0.6 1.05 
+[BinnedSplineHandler.cpp][info] Left PrintBinning now tidying up
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Sample BeamND_RHC_CCnumu has 4 oscillation channels
+[BinnedSplineHandler.cpp][info] Oscillation channel 0 has 54 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 1 has 54 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 2 has 54 systematics
+[BinnedSplineHandler.cpp][info] Oscillation channel 3 has 54 systematics
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Printing no. of modes affected by each systematic for each oscillation channel
+[BinnedSplineHandler.cpp][info] OscChan: 0	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 
+[BinnedSplineHandler.cpp][info] OscChan: 1	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 
+[BinnedSplineHandler.cpp][info] OscChan: 2	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 
+[BinnedSplineHandler.cpp][info] OscChan: 3	1 1 1 1 1 1 2 2 2 2 2 4 4 4 4 4 6 6 6 6 6 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 5 
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_RHC_ger_numu_x_numu_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_RHC_ger_nue_x_nue_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_RHC_ger_numubar_x_numubar_splines.root
+[BinnedSplineHandler.cpp][info] Processing: Inputs/DUNE_ND_spline_files/ND_RHC_ger_nuebar_x_nuebar_splines.root
+[BinnedSplineHandler.cpp][info] #----------------------------------------------------------------------------------------------------------------------------------#
+[BinnedSplineHandler.cpp][info] Total number of splines loaded: 342528
+[BinnedSplineHandler.cpp][info] Total number of non-flat splines loaded: 20364
+[BinnedSplineHandler.cpp][info] nUniqueSysts: 55
+[BinnedSplineHandler.cpp][info] Spline Index    | Syst Name            | nKnots
+[BinnedSplineHandler.cpp][info] 0               | maqe                 | 7     
+[BinnedSplineHandler.cpp][info] 1               | pauli                | 2     
+[BinnedSplineHandler.cpp][info] 2               | mares                | 8     
+[BinnedSplineHandler.cpp][info] 3               | mvres                | 7     
+[BinnedSplineHandler.cpp][info] 4               | mancres              | 7     
+[BinnedSplineHandler.cpp][info] 5               | mvncres              | 7     
+[BinnedSplineHandler.cpp][info] 6               | thetadelta           | 2     
+[BinnedSplineHandler.cpp][info] 7               | ahtby                | 7     
+[BinnedSplineHandler.cpp][info] 8               | bhtby                | 7     
+[BinnedSplineHandler.cpp][info] 9               | cv1uby               | 7     
+[BinnedSplineHandler.cpp][info] 10              | cv2uby               | 7     
+[BinnedSplineHandler.cpp][info] 11              | frcexpi              | 7     
+[BinnedSplineHandler.cpp][info] 12              | frelaspi             | 7     
+[BinnedSplineHandler.cpp][info] 13              | frinelpi             | 7     
+[BinnedSplineHandler.cpp][info] 14              | frabspi              | 7     
+[BinnedSplineHandler.cpp][info] 15              | frpiprodpi           | 7     
+[BinnedSplineHandler.cpp][info] 16              | frcexn               | 7     
+[BinnedSplineHandler.cpp][info] 17              | frelasn              | 7     
+[BinnedSplineHandler.cpp][info] 18              | frineln              | 7     
+[BinnedSplineHandler.cpp][info] 19              | frabsn               | 7     
+[BinnedSplineHandler.cpp][info] 20              | frpiprodn            | 7     
+[BinnedSplineHandler.cpp][info] 21              | e2anu                | 5     
+[BinnedSplineHandler.cpp][info] 22              | e2bnu                | 5     
+[BinnedSplineHandler.cpp][info] 23              | e2anubar             | 5     
+[BinnedSplineHandler.cpp][info] 24              | e2bnubar             | 5     
+[BinnedSplineHandler.cpp][info] 25              | c12nu                | 2     
+[BinnedSplineHandler.cpp][info] 26              | c12nubar             | 2     
+[BinnedSplineHandler.cpp][info] 27              | nuncc2               | 6     
+[BinnedSplineHandler.cpp][info] 28              | nuncc3               | 6     
+[BinnedSplineHandler.cpp][info] 29              | nupcc2               | 6     
+[BinnedSplineHandler.cpp][info] 30              | nupcc3               | 6     
+[BinnedSplineHandler.cpp][info] 31              | nunpcc1              | 8     
+[BinnedSplineHandler.cpp][info] 32              | nunnc1               | 6     
+[BinnedSplineHandler.cpp][info] 33              | nunnc2               | 6     
+[BinnedSplineHandler.cpp][info] 34              | nunnc3               | 6     
+[BinnedSplineHandler.cpp][info] 35              | nupnc1               | 6     
+[BinnedSplineHandler.cpp][info] 36              | nupnc2               | 6     
+[BinnedSplineHandler.cpp][info] 37              | nupnc3               | 6     
+[BinnedSplineHandler.cpp][info] 38              | nubarncc1            | 6     
+[BinnedSplineHandler.cpp][info] 39              | nubarncc2            | 6     
+[BinnedSplineHandler.cpp][info] 40              | nubarncc3            | 6     
+[BinnedSplineHandler.cpp][info] 41              | nubarpcc1            | 6     
+[BinnedSplineHandler.cpp][info] 42              | nubarpcc2            | 6     
+[BinnedSplineHandler.cpp][info] 43              | nubarpcc3            | 6     
+[BinnedSplineHandler.cpp][info] 44              | nubarnnc1            | 6     
+[BinnedSplineHandler.cpp][info] 45              | nubarnnc2            | 6     
+[BinnedSplineHandler.cpp][info] 46              | nubarnnc3            | 6     
+[BinnedSplineHandler.cpp][info] 47              | nubarpnc1            | 6     
+[BinnedSplineHandler.cpp][info] 48              | nubarpnc2            | 6     
+[BinnedSplineHandler.cpp][info] 49              | nubarpnc3            | 6     
+[BinnedSplineHandler.cpp][info] 50              | berpaa               | 7     
+[BinnedSplineHandler.cpp][info] 51              | berpab               | 7     
+[BinnedSplineHandler.cpp][info] 52              | berpad               | 7     
+[BinnedSplineHandler.cpp][info] 53              | nuexsec              | 2     
+[BinnedSplineHandler.cpp][info] 54              | nuemuxsec            | 2     
+[BinnedSplineHandler.cpp][info] Number of combinations of Sample, OscChan, Syst and Mode which have entirely flat response: 322164 / 342528
+[BinnedSplineHandler.cpp][info] Total number of splines loaded: 342528
+[BinnedSplineHandler.cpp][info] Total number of non-flat splines loaded: 20364
+[BinnedSplineHandler.cpp][info] Now transferring splines to a monolith if size 342528
+[SampleHandlerBase.cpp][info] --------------------------------
+[SampleHandlerBase.cpp][info] Setup Far Detector splines
+[BinnedSplineHandler.cpp][info] Cleaning up spline memory
+[SampleHandlerBase.cpp][info] Setting up Normalisation Pointers..
+[SampleHandlerBase.cpp][info] Setting up Functional Pointers..
+[SampleHandlerBase.cpp][info] Finished setting up functional parameters
+[SampleHandlerBase.cpp][info] Setting up Additional Weight Pointers..
+[SampleHandlerBase.cpp][info] Setting up Kinematic Map..
+[SampleHandlerBase.cpp][info] Finished loading MC for BeamND, it took 109.40s to finish
+[SampleHandlerBase.cpp][info] Initialising Data
+[SampleHandlerBase.cpp][info] =======================================================
+[EventRates.cpp][info] Event rate for BeamFD_FHC_numu : 8263.78
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamFD_FHC_numu
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | FHC_numu_x_numu   | FHC_nue_x_nue     | FHC_numubar_x_numubar | FHC_nuebar_x_nuebar | FHC_numu_x_nue    | FHC_numubar_x_nuebar | FHC_nue_x_numu    | FHC_nuebar_x_numubar | FHC_numu_x_nutau  | FHC_nue_x_nutau   | FHC_numubar_x_nutaubar | FHC_nuebar_x_nutaubar | Total      |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 2008.2327         | 0.0000            | 93.3041           | 0.0000            | 0.2435            | 0.0000            | 1.7795            | 0.1642            | 26.1527           | 0.0792            | 2.3498            | 0.0021            | 2132.3079  |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 2608.2018         | 3.4638            | 247.7396          | 0.0000            | 6.0060            | 0.0451            | 3.3091            | 0.2552            | 8.0563            | 0.0158            | 1.0746            | 0.0000            | 2878.1674  |
+[SampleHandlerBase.cpp][info] | CCRES    | 2235.7074         | 0.0000            | 159.5292          | 0.0000            | 1.3835            | 0.0000            | 3.0239            | 0.1884            | 12.6281           | 0.0402            | 2.7477            | 0.0000            | 2415.2483  |
+[SampleHandlerBase.cpp][info] | CCCOH    | 44.9769           | 0.0000            | 7.4374            | 0.0000            | 0.0000            | 0.0000            | 0.0540            | 0.0091            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 52.4773    |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.8022            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.8022     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 540.9073          | 0.0000            | 39.1243           | 0.0000            | 0.0000            | 0.0000            | 0.5042            | 0.0668            | 3.0614            | 0.0062            | 0.2328            | 0.0000            | 583.9029   |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 0.0000            | 0.0000            | 0.8370            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.8370     |
+[SampleHandlerBase.cpp][info] | NCDIS    | 150.6591          | 4.1850            | 9.2069            | 0.8370            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 164.8880   |
+[SampleHandlerBase.cpp][info] | NCRES    | 32.6428           | 0.8370            | 1.6740            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 35.1538    |
+[SampleHandlerBase.cpp][info] | NCCOH    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 7622.1302         | 8.4858            | 558.8525          | 0.8370            | 7.6331            | 0.0451            | 8.6707            | 0.6837            | 49.8985           | 0.1413            | 6.4050            | 0.0021            | 8263.7849  |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] Event rate for BeamFD_FHC_nue : 1776.70
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamFD_FHC_nue
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | FHC_numu_x_numu   | FHC_nue_x_nue     | FHC_numubar_x_numubar | FHC_nuebar_x_nuebar | FHC_numu_x_nue    | FHC_numubar_x_nuebar | FHC_nue_x_numu    | FHC_nuebar_x_numubar | FHC_numu_x_nutau  | FHC_nue_x_nutau   | FHC_numubar_x_nutaubar | FHC_nuebar_x_nutaubar | Total      |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 1.2547            | 49.7144           | 0.0000            | 3.8014            | 374.1703          | 2.9507            | 0.0000            | 0.0000            | 20.4625           | 0.0549            | 2.1088            | 0.0032            | 454.5210   |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 11.8747           | 90.0403           | 0.2905            | 16.3591           | 379.0793          | 4.4803            | 0.0000            | 0.0000            | 3.6965            | 0.0039            | 0.5348            | 0.0000            | 506.3594   |
+[SampleHandlerBase.cpp][info] | CCRES    | 2.2066            | 68.4697           | 0.0000            | 8.9339            | 498.5283          | 5.2531            | 0.0000            | 0.0000            | 8.3472            | 0.0372            | 2.0447            | 0.0019            | 593.8226   |
+[SampleHandlerBase.cpp][info] | CCCOH    | 0.0000            | 2.3231            | 0.0000            | 0.8057            | 10.5882           | 0.1925            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 13.9095    |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.4938            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.4938     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 0.0000            | 9.1330            | 0.0000            | 2.4669            | 107.7748          | 1.2349            | 0.0000            | 0.0000            | 2.8611            | 0.0000            | 0.4213            | 0.0000            | 123.8920   |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDIS    | 61.9376           | 0.8370            | 5.8590            | 0.8370            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 69.4706    |
+[SampleHandlerBase.cpp][info] | NCRES    | 8.3699            | 0.0000            | 0.8370            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 9.2069     |
+[SampleHandlerBase.cpp][info] | NCCOH    | 1.6740            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 1.6740     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 3.3480            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 3.3480     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 90.6656           | 220.5175          | 6.9865            | 33.2041           | 1370.6346         | 14.1115           | 0.0000            | 0.0000            | 35.3673           | 0.0960            | 5.1096            | 0.0051            | 1776.6978  |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] Event rate for BeamFD_RHC_numu : 4363.52
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamFD_RHC_numu
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | RHC_numu_x_numu   | RHC_nue_x_nue     | RHC_numubar_x_numubar | RHC_nuebar_x_nuebar | RHC_numu_x_nue    | RHC_numubar_x_nuebar | RHC_nue_x_numu    | RHC_nuebar_x_numubar | RHC_numu_x_nutau  | RHC_nue_x_nutau   | RHC_numubar_x_nutaubar | RHC_nuebar_x_nutaubar | Total      |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 263.8222          | 0.0000            | 667.3853          | 0.0000            | 0.0643            | 0.0000            | 0.4948            | 0.4260            | 6.3752            | 0.0068            | 6.7860            | 0.0083            | 945.3689   |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 875.0693          | 0.4148            | 792.4957          | 0.4091            | 0.4921            | 0.3236            | 1.1816            | 0.5837            | 4.0688            | 0.0196            | 2.2914            | 0.0042            | 1677.3540  |
+[SampleHandlerBase.cpp][info] | CCRES    | 335.4014          | 0.0000            | 921.7726          | 0.0000            | 0.0556            | 0.0386            | 0.6417            | 0.7084            | 6.4823            | 0.0233            | 5.5368            | 0.0092            | 1270.6697  |
+[SampleHandlerBase.cpp][info] | CCCOH    | 10.2489           | 0.0000            | 33.4685           | 0.0000            | 0.0000            | 0.0000            | 0.0125            | 0.0158            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 43.7458    |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.4093            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0005            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.4098     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 71.4274           | 0.0000            | 244.4010          | 0.0000            | 0.0000            | 0.0000            | 0.1041            | 0.1816            | 1.0998            | 0.0000            | 1.4285            | 0.0000            | 318.6425   |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 0.0000            | 0.0000            | 0.4160            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.4160     |
+[SampleHandlerBase.cpp][info] | NCDIS    | 46.5914           | 2.4960            | 34.9436           | 0.4160            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 84.4469    |
+[SampleHandlerBase.cpp][info] | NCRES    | 4.5759            | 0.4160            | 17.4718           | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 22.4637    |
+[SampleHandlerBase.cpp][info] | NCCOH    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 1607.5458         | 3.3268            | 2712.3545         | 0.8251            | 0.6120            | 0.3627            | 2.4346            | 1.9155            | 18.0262           | 0.0498            | 16.0426           | 0.0218            | 4363.5174  |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] Event rate for BeamFD_RHC_nue : 492.04
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamFD_RHC_nue
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | RHC_numu_x_numu   | RHC_nue_x_nue     | RHC_numubar_x_numubar | RHC_nuebar_x_nuebar | RHC_numu_x_nue    | RHC_numubar_x_nuebar | RHC_nue_x_numu    | RHC_nuebar_x_numubar | RHC_numu_x_nutau  | RHC_nue_x_nutau   | RHC_numubar_x_nutaubar | RHC_nuebar_x_nutaubar | Total      |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 0.3921            | 12.4458           | 0.1677            | 18.9328           | 25.2854           | 43.4743           | 0.0000            | 0.0000            | 4.0145            | 0.0305            | 6.6920            | 0.0037            | 111.4386   |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 6.6241            | 31.3806           | 1.1707            | 24.6440           | 30.0114           | 46.3652           | 0.0108            | 0.0020            | 2.1937            | 0.0073            | 1.0711            | 0.0056            | 143.4865   |
+[SampleHandlerBase.cpp][info] | CCRES    | 0.0000            | 21.7250           | 0.3113            | 25.5790           | 28.6855           | 69.5289           | 0.0000            | 0.0000            | 4.7418            | 0.0193            | 3.5735            | 0.0023            | 154.1667   |
+[SampleHandlerBase.cpp][info] | CCCOH    | 0.0000            | 1.5424            | 0.0000            | 2.4101            | 0.9044            | 2.9933            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 7.8503     |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0245            | 0.0304            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0549     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 0.0000            | 3.5103            | 0.0000            | 6.0520            | 6.6622            | 17.8204           | 0.0000            | 0.0000            | 0.7286            | 0.0000            | 0.7510            | 0.0000            | 35.5244    |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDIS    | 15.3918           | 0.0000            | 18.7198           | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 34.1116    |
+[SampleHandlerBase.cpp][info] | NCRES    | 0.4160            | 0.0000            | 2.0800            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 2.4960     |
+[SampleHandlerBase.cpp][info] | NCCOH    | 0.4160            | 0.0000            | 0.8320            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 1.2480     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 0.4160            | 0.0000            | 1.2480            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 1.6640     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 23.6560           | 70.6041           | 24.5294           | 77.6179           | 91.5735           | 180.2125          | 0.0108            | 0.0020            | 11.6784           | 0.0571            | 12.0876           | 0.0116            | 492.0409   |
+[SampleHandlerBase.cpp][info] -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] Event rate for BeamND_FHC_CCnumu : 68216783.24
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamND_FHC_CCnumu
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | FHC_numu_x_numu   | FHC_nue_x_nue     | FHC_numubar_x_numubar | FHC_nuebar_x_nuebar | Total      |
+[SampleHandlerBase.cpp][info] ---------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 20384110.4301     | 20.2100           | 40227.9228        | 0.0000            | 20424358.5629 |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 15156388.9592     | 60.6299           | 33892.1260        | 0.0000            | 15190341.7151 |
+[SampleHandlerBase.cpp][info] | CCRES    | 24435656.9759     | 0.0000            | 64186.8767        | 0.0000            | 24499843.8526 |
+[SampleHandlerBase.cpp][info] | CCCOH    | 558846.1942       | 0.0000            | 2445.4068         | 0.0000            | 561291.6010 |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 6494798.4252      | 0.0000            | 16612.5984        | 0.0000            | 6511411.0236 |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 7113.9108         | 141.4698          | 242.5197          | 0.0000            | 7497.9003  |
+[SampleHandlerBase.cpp][info] | NCDIS    | 587382.6772       | 8488.1890         | 29041.7323        | 1556.1680         | 626468.7664 |
+[SampleHandlerBase.cpp][info] | NCRES    | 373864.3045       | 4062.2047         | 16875.3281        | 767.9790          | 395569.8163 |
+[SampleHandlerBase.cpp][info] | NCCOH    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 67998161.8770     | 12772.7034        | 203524.5108       | 2324.1470         | 68216783.2382 |
+[SampleHandlerBase.cpp][info] ---------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] Event rate for BeamND_RHC_CCnumu : 27773916.19
+[SampleHandlerBase.cpp][info] -------------------------------------------------
+[SampleHandlerBase.cpp][info] Integral breakdown for sample: BeamND_RHC_CCnumu
+[SampleHandlerBase.cpp][info] 
+[SampleHandlerBase.cpp][info] | Mode     | RHC_numu_x_numu   | RHC_nue_x_nue     | RHC_numubar_x_numubar | RHC_nuebar_x_nuebar | Total      |
+[SampleHandlerBase.cpp][info] ---------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] | CCQE     | 50642.0204        | 25.6667           | 8088684.8316      | 0.0000            | 8139352.5187 |
+[SampleHandlerBase.cpp][info] | CC1Kaon  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCDIS    | 57031.3332        | 25.6667           | 4752825.0000      | 0.0000            | 4809881.9999 |
+[SampleHandlerBase.cpp][info] | CCRES    | 63242.6668        | 0.0000            | 10939056.3412     | 0.0000            | 11002299.0080 |
+[SampleHandlerBase.cpp][info] | CCCOH    | 667.3333          | 0.0000            | 468391.0000       | 0.0000            | 469058.3333 |
+[SampleHandlerBase.cpp][info] | CCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCMEC    | 13526.3333        | 0.0000            | 3137519.0000      | 0.0000            | 3151045.3333 |
+[SampleHandlerBase.cpp][info] | CCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | CCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCQE     | 256.6667          | 25.6667           | 847.0000          | 0.0000            | 1129.3333  |
+[SampleHandlerBase.cpp][info] | NCDIS    | 34496.0000        | 1540.0000         | 78771.0000        | 1155.0000         | 115962.0000 |
+[SampleHandlerBase.cpp][info] | NCRES    | 13115.6667        | 487.6667          | 70737.3333        | 847.0000          | 85187.6667 |
+[SampleHandlerBase.cpp][info] | NCCOH    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCDiff   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCNuEl   | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCAnuGam | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCMEC    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCCOHEL  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIBD    | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCGlRES  | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | NCIMDAnn | 0.0000            | 0.0000            | 0.0000            | 0.0000            | 0.0000     |
+[SampleHandlerBase.cpp][info] | Total    | 232978.0204       | 2104.6667         | 27536831.5061     | 2002.0000         | 27773916.1932 |
+[SampleHandlerBase.cpp][info] ---------------------------------------------------------------------------------------------------------
+[SampleHandlerBase.cpp][info] 
+[EventRates.cpp][info] ========================================================================
+[EventRates.cpp][info] ========================================================================
+[EventRates.cpp][info] Oscillation Mode Breakdown:
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numu_x_numu      : 7622.13             
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nue_x_nue        : 8.49                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numubar_x_numubar : 558.85              
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nuebar_x_nuebar  : 0.84                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numu_x_nue       : 7.63                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numubar_x_nuebar : 0.05                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nue_x_numu       : 8.67                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nuebar_x_numubar : 0.68                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numu_x_nutau     : 49.90               
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nue_x_nutau      : 0.14                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_numubar_x_nutaubar : 6.40                
+[EventRates.cpp][info] BeamFD_FHC_numu      : FHC_nuebar_x_nutaubar : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : 8263.78             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numu_x_numu      : 90.67               
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nue_x_nue        : 220.52              
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numubar_x_numubar : 6.99                
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nuebar_x_nuebar  : 33.20               
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numu_x_nue       : 1370.63             
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numubar_x_nuebar : 14.11               
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nue_x_numu       : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nuebar_x_numubar : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numu_x_nutau     : 35.37               
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nue_x_nutau      : 0.10                
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_numubar_x_nutaubar : 5.11                
+[EventRates.cpp][info] BeamFD_FHC_nue       : FHC_nuebar_x_nutaubar : 0.01                
+[EventRates.cpp][info] BeamFD_FHC_nue       : 1776.70             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numu_x_numu      : 1607.55             
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nue_x_nue        : 3.33                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numubar_x_numubar : 2712.35             
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nuebar_x_nuebar  : 0.83                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numu_x_nue       : 0.61                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numubar_x_nuebar : 0.36                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nue_x_numu       : 2.43                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nuebar_x_numubar : 1.92                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numu_x_nutau     : 18.03               
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nue_x_nutau      : 0.05                
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_numubar_x_nutaubar : 16.04               
+[EventRates.cpp][info] BeamFD_RHC_numu      : RHC_nuebar_x_nutaubar : 0.02                
+[EventRates.cpp][info] BeamFD_RHC_numu      : 4363.52             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numu_x_numu      : 23.66               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nue_x_nue        : 70.60               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numubar_x_numubar : 24.53               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nuebar_x_nuebar  : 77.62               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numu_x_nue       : 91.57               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numubar_x_nuebar : 180.21              
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nue_x_numu       : 0.01                
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nuebar_x_numubar : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numu_x_nutau     : 11.68               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nue_x_nutau      : 0.06                
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_numubar_x_nutaubar : 12.09               
+[EventRates.cpp][info] BeamFD_RHC_nue       : RHC_nuebar_x_nutaubar : 0.01                
+[EventRates.cpp][info] BeamFD_RHC_nue       : 492.04              
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : FHC_numu_x_numu      : 67998161.88         
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : FHC_nue_x_nue        : 12772.70            
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : FHC_numubar_x_numubar : 203524.51           
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : FHC_nuebar_x_nuebar  : 2324.15             
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : 68216783.24         
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : RHC_numu_x_numu      : 232978.02           
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : RHC_nue_x_nue        : 2104.67             
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : RHC_numubar_x_numubar : 27536831.51         
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : RHC_nuebar_x_nuebar  : 2002.00             
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : 27773916.19         
+[EventRates.cpp][info] ========================================================================
+[EventRates.cpp][info] ========================================================================
+[EventRates.cpp][info] Interaction Mode Breakdown:
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCQE                 : 2132.31             
+[EventRates.cpp][info] BeamFD_FHC_numu      : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCDIS                : 2878.17             
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCRES                : 2415.25             
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCCOH                : 52.48               
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCNuEl               : 0.80                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCMEC                : 583.90              
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCQE                 : 0.84                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCDIS                : 164.89              
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCRES                : 35.15               
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCCOH                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCNuEl               : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_numu      : 8263.78             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCQE                 : 454.52              
+[EventRates.cpp][info] BeamFD_FHC_nue       : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCDIS                : 506.36              
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCRES                : 593.82              
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCCOH                : 13.91               
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCNuEl               : 0.49                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCMEC                : 123.89              
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCQE                 : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCDIS                : 69.47               
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCRES                : 9.21                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCCOH                : 1.67                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCNuEl               : 3.35                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_FHC_nue       : 1776.70             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCQE                 : 945.37              
+[EventRates.cpp][info] BeamFD_RHC_numu      : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCDIS                : 1677.35             
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCRES                : 1270.67             
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCCOH                : 43.75               
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCNuEl               : 0.41                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCMEC                : 318.64              
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCQE                 : 0.42                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCDIS                : 84.45               
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCRES                : 22.46               
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCCOH                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCNuEl               : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_numu      : 4363.52             
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCQE                 : 111.44              
+[EventRates.cpp][info] BeamFD_RHC_nue       : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCDIS                : 143.49              
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCRES                : 154.17              
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCCOH                : 7.85                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCNuEl               : 0.05                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCMEC                : 35.52               
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCQE                 : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCDIS                : 34.11               
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCRES                : 2.50                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCCOH                : 1.25                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCNuEl               : 1.66                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamFD_RHC_nue       : 492.04              
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCQE                 : 20424358.56         
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCDIS                : 15190341.72         
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCRES                : 24499843.85         
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCCOH                : 561291.60           
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCNuEl               : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCMEC                : 6511411.02          
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCQE                 : 7497.90             
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCDIS                : 626468.77           
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCRES                : 395569.82           
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCCOH                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCNuEl               : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamND_FHC_CCnumu    : 68216783.24         
+[EventRates.cpp][info] ======================
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCQE                 : 8139352.52          
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CC1Kaon              : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCDIS                : 4809882.00          
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCRES                : 11002299.01         
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCCOH                : 469058.33           
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCDiff               : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCNuEl               : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCIMD                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCMEC                : 3151045.33          
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCIBD                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCGlRES              : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : CCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCQE                 : 1129.33             
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCDIS                : 115962.00           
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCRES                : 85187.67            
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCCOH                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCDiff               : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCNuEl               : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCIMD                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCAnuGam             : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCMEC                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCCOHEL              : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCIBD                : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCGlRES              : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : NCIMDAnn             : 0.00                
+[EventRates.cpp][info] BeamND_RHC_CCnumu    : 27773916.19         

--- a/Samples/SampleHandlerBeamFD.cpp
+++ b/Samples/SampleHandlerBeamFD.cpp
@@ -26,6 +26,9 @@ void SampleHandlerBeamFD::Init() {
     MACH3LOG_INFO("- isFHC: {}", beamFDSampleDetails[i].isFHC);
     MACH3LOG_INFO("- iselike: {}", beamFDSampleDetails[i].iselike);
   }
+
+  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  MACH3LOG_INFO("Beam FD downsampling step: {}", downsamplingStep);
   
   MACH3LOG_INFO("-------------------------------------------------------------------");
 }
@@ -480,8 +483,9 @@ int SampleHandlerBeamFD::SetupExperimentMC() {
   _data->SetBranchAddress("vtx_z", &_vtx_z);  
 
   size_t nEntries = static_cast<size_t>(_data->GetEntries());
-  size_t countwidth = nEntries / 5;
-  dunemcSamples.resize(nEntries);
+  size_t nDownsampledEntries = nEntries / downsamplingStep;
+  size_t countwidth = nDownsampledEntries / 5;
+  dunemcSamples.resize(nDownsampledEntries);
   _data->GetEntry(0);
 
   // HH: A map to keep track of negative energies
@@ -494,11 +498,11 @@ int SampleHandlerBeamFD::SetupExperimentMC() {
   negative_counts["rw_sum_ehad"] = 0;
   
   //FILL DUNE STRUCT
-  for (unsigned int i = 0; i < nEntries; ++i) { // Loop through tree
-    _data->GetEntry(i);
+  for (unsigned int i = 0; i < nDownsampledEntries; ++i) { // Loop through tree
+    _data->GetEntry(i * downsamplingStep);
 
     if (i % countwidth == 0) {
-      M3::Utils::PrintProgressBar(i, static_cast<Long64_t>(nEntries));
+      M3::Utils::PrintProgressBar(i, static_cast<Long64_t>(nDownsampledEntries));
     }
 
     const size_t sample_index = fileIndexToSample[static_cast<size_t>(_data->GetTreeNumber())];
@@ -510,7 +514,7 @@ int SampleHandlerBeamFD::SetupExperimentMC() {
 
     // POT stuff
     dunemcSamples[i].norm_s = fileIndexToNorm[static_cast<size_t>(_data->GetTreeNumber())][0]; // Norm in sample
-    dunemcSamples[i].pot_s = fileIndexToNorm[static_cast<size_t>(_data->GetTreeNumber())][1]; // POT in sample
+    dunemcSamples[i].pot_s = fileIndexToNorm[static_cast<size_t>(_data->GetTreeNumber())][1] * downsamplingStep; // POT in sample
     
     dunemcSamples[i].rw_cvnnumu = (_cvnnumu);
     dunemcSamples[i].rw_cvnnue = (_cvnnue);
@@ -601,7 +605,7 @@ int SampleHandlerBeamFD::SetupExperimentMC() {
   }
   
   delete _data;
-  return static_cast<int>(nEntries);
+  return static_cast<int>(nDownsampledEntries);
 }
 
 const double* SampleHandlerBeamFD::GetPointerToKinematicParameter(const int KinPar, const int iEvent) const {

--- a/Samples/SampleHandlerBeamFD.cpp
+++ b/Samples/SampleHandlerBeamFD.cpp
@@ -5,6 +5,8 @@ SampleHandlerBeamFD::SampleHandlerBeamFD(std::string mc_version_, ParameterHandl
   ReversedKinematicParameters = &ReversedKinematicParametersDUNE;
   
   Initialise();
+
+  downsamplingStep = 1;
 }
 
 SampleHandlerBeamFD::~SampleHandlerBeamFD() {

--- a/Samples/SampleHandlerBeamFD.cpp
+++ b/Samples/SampleHandlerBeamFD.cpp
@@ -30,6 +30,11 @@ void SampleHandlerBeamFD::Init() {
   }
 
   downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  if (downsamplingStep == 0) {
+    throw MaCh3Exception(__FILE__, __LINE__,
+      "Downsampling step cannot be zero. Please set it to a positive integer in the Beam FD sample config file."
+    );
+  } 
   MACH3LOG_INFO("Beam FD downsampling step: {}", downsamplingStep);
   
   MACH3LOG_INFO("-------------------------------------------------------------------");
@@ -486,6 +491,11 @@ int SampleHandlerBeamFD::SetupExperimentMC() {
 
   size_t nEntries = static_cast<size_t>(_data->GetEntries());
   size_t nDownsampledEntries = nEntries / downsamplingStep;
+  if (nDownsampledEntries == 0) {
+    throw MaCh3Exception(__FILE__, __LINE__,
+      "Downsampling step is too large, resulting in zero entries. Please set it to a smaller positive integer in the Beam FD sample config file."
+    );
+  }
   size_t countwidth = nDownsampledEntries / 5;
   dunemcSamples.resize(nDownsampledEntries);
   _data->GetEntry(0);

--- a/Samples/SampleHandlerBeamFD.cpp
+++ b/Samples/SampleHandlerBeamFD.cpp
@@ -29,7 +29,7 @@ void SampleHandlerBeamFD::Init() {
     MACH3LOG_INFO("- iselike: {}", beamFDSampleDetails[i].iselike);
   }
 
-  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["DownsamplingStep"], 1);
   if (downsamplingStep == 0) {
     throw MaCh3Exception(__FILE__, __LINE__,
       "Downsampling step cannot be zero. Please set it to a positive integer in the Beam FD sample config file."

--- a/Samples/SampleHandlerBeamFD.h
+++ b/Samples/SampleHandlerBeamFD.h
@@ -168,6 +168,9 @@ protected:
   };
   std::unordered_map<std::string, std::vector<double>> norm_map;
 
+  /// @brief Downsampling step (e.g. 10 means only every 10th event is used in the fit). Default is 1 (no downsampling).
+  unsigned int downsamplingStep = 1;
+
   /// @brief Cleanup memory
   void CleanMemoryBeforeFit() override {};
 };

--- a/Samples/SampleHandlerBeamFD.h
+++ b/Samples/SampleHandlerBeamFD.h
@@ -169,7 +169,7 @@ protected:
   std::unordered_map<std::string, std::vector<double>> norm_map;
 
   /// @brief Downsampling step (e.g. 10 means only every 10th event is used in the fit). Default is 1 (no downsampling).
-  unsigned int downsamplingStep = 1;
+  unsigned int downsamplingStep;
 
   /// @brief Cleanup memory
   void CleanMemoryBeforeFit() override {};

--- a/Samples/SampleHandlerBeamND.cpp
+++ b/Samples/SampleHandlerBeamND.cpp
@@ -14,6 +14,8 @@ SampleHandlerBeamND::SampleHandlerBeamND(std::string mc_version_, ParameterHandl
   ReversedKinematicParameters = &ReversedKinematicParametersDUNE;
   
   Initialise();
+
+  downsamplingStep = 1;
 }
 
 SampleHandlerBeamND::~SampleHandlerBeamND() {

--- a/Samples/SampleHandlerBeamND.cpp
+++ b/Samples/SampleHandlerBeamND.cpp
@@ -42,6 +42,9 @@ void SampleHandlerBeamND::Init() {
     MACH3LOG_INFO("- iselike: {}", beamNDSampleDetails[i].iselike);
   }
 
+  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  MACH3LOG_INFO("Beam ND downsampling step: {}", downsamplingStep);
+
   MACH3LOG_INFO("-------------------------------------------------------------------");
 }
 
@@ -141,16 +144,17 @@ int SampleHandlerBeamND::SetupExperimentMC() {
   _data->SetBranchAddress("BeRPA_A_cvwgt", &_BeRPA_cvwgt);
 
   size_t nEntries = static_cast<size_t>(_data->GetEntries());
-  size_t countwidth = nEntries / 10;
-  dunendmcSamples.resize(nEntries);
+  size_t nDownsampledEntries = nEntries / downsamplingStep;
+  size_t countwidth = nDownsampledEntries / 10;
+  dunendmcSamples.resize(nDownsampledEntries);
   _data->GetEntry(0);
 
   //FILL DUNE STRUCT
-  for (unsigned int i = 0; i < nEntries; ++i) { // Loop through tree
-    _data->GetEntry(i);
+  for (unsigned int i = 0; i < nDownsampledEntries; ++i) { // Loop through tree
+    _data->GetEntry(i * downsamplingStep);
 
     if (i % countwidth == 0) {
-      M3::Utils::PrintProgressBar(i, static_cast<Long64_t>(nEntries));
+      M3::Utils::PrintProgressBar(i, static_cast<Long64_t>(nDownsampledEntries));
     }
 
     const Int_t treeNum = _data->GetTreeNumber();
@@ -166,7 +170,7 @@ int SampleHandlerBeamND::SetupExperimentMC() {
 
     // POT stuff
     dunendmcSamples[i].norm_s = beamNDSampleDetails[sample_index].norm_s;
-    dunendmcSamples[i].pot_s = beamNDSampleDetails[sample_index].pot_s;
+    dunendmcSamples[i].pot_s = beamNDSampleDetails[sample_index].pot_s * downsamplingStep;
     
     dunendmcSamples[i].rw_erec = _erec;
     dunendmcSamples[i].rw_erec_shifted = _erec;
@@ -193,7 +197,7 @@ int SampleHandlerBeamND::SetupExperimentMC() {
   //_sampleFile->Close();
   _data->Reset();
   delete _data;
-  return static_cast<int>(nEntries);
+  return static_cast<int>(nDownsampledEntries);
   
 }
 

--- a/Samples/SampleHandlerBeamND.cpp
+++ b/Samples/SampleHandlerBeamND.cpp
@@ -45,6 +45,11 @@ void SampleHandlerBeamND::Init() {
   }
 
   downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  if (downsamplingStep == 0) {
+    throw MaCh3Exception(__FILE__, __LINE__,
+      "Downsampling step cannot be zero. Please set it to a positive integer in the Beam ND sample config file."
+    );
+  } 
   MACH3LOG_INFO("Beam ND downsampling step: {}", downsamplingStep);
 
   MACH3LOG_INFO("-------------------------------------------------------------------");
@@ -147,6 +152,11 @@ int SampleHandlerBeamND::SetupExperimentMC() {
 
   size_t nEntries = static_cast<size_t>(_data->GetEntries());
   size_t nDownsampledEntries = nEntries / downsamplingStep;
+  if (nDownsampledEntries == 0) {
+    throw MaCh3Exception(__FILE__, __LINE__,
+      "Downsampling step is too large, resulting in zero entries. Please set it to a smaller positive integer in the Beam ND sample config file."
+    );
+  }
   size_t countwidth = nDownsampledEntries / 10;
   dunendmcSamples.resize(nDownsampledEntries);
   _data->GetEntry(0);

--- a/Samples/SampleHandlerBeamND.cpp
+++ b/Samples/SampleHandlerBeamND.cpp
@@ -44,7 +44,7 @@ void SampleHandlerBeamND::Init() {
     MACH3LOG_INFO("- iselike: {}", beamNDSampleDetails[i].iselike);
   }
 
-  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["downsamplingStep"], 1);
+  downsamplingStep = GetFromManager<unsigned int>(SampleManager->raw()["DownsamplingStep"], 1);
   if (downsamplingStep == 0) {
     throw MaCh3Exception(__FILE__, __LINE__,
       "Downsampling step cannot be zero. Please set it to a positive integer in the Beam ND sample config file."

--- a/Samples/SampleHandlerBeamND.h
+++ b/Samples/SampleHandlerBeamND.h
@@ -118,6 +118,9 @@ protected:
   int nNDDetectorSystPointers;
   std::unordered_map<std::string, std::vector<double>> norm_map;
 
+  /// @brief Downsampling step (e.g. 10 means only every 10th event is used in the fit). Default is 1 (no downsampling).
+  unsigned int downsamplingStep = 1;
+
   /// @brief Cleanup memory
   void CleanMemoryBeforeFit() override {};
 };

--- a/Samples/SampleHandlerBeamND.h
+++ b/Samples/SampleHandlerBeamND.h
@@ -119,7 +119,7 @@ protected:
   std::unordered_map<std::string, std::vector<double>> norm_map;
 
   /// @brief Downsampling step (e.g. 10 means only every 10th event is used in the fit). Default is 1 (no downsampling).
-  unsigned int downsamplingStep = 1;
+  unsigned int downsamplingStep;
 
   /// @brief Cleanup memory
   void CleanMemoryBeforeFit() override {};


### PR DESCRIPTION
# Pull request description

This PR allows a user to downsample the ND and/or FD Beam samples by skipping events during read-in, and up-weighting the remaining events accordingly. This creates samples with **approximately** the same event rates, but with fewer events, therefore leading to faster fits. 

This is useful for testing and rough studies. In my case, I have used it to speed up adaptive fits that I have been using to derive proposal matrices, which I then use in later fits with the full statistics.

The number of steps that are skipped is configured by the **new** `downsamplingStep` option in `SampleHandler_FD_Beam.yaml` and `SampleHandler_ND_Beam.yaml`. By default, this option is set to 1, i.e. no downsampling.

I have checked that the output of EventRates is unchanged when `downsamplingStep = 1`. I have also added the output of EventRates for `downsamplingStep = 10` to `Docs/`. This demonstrates that the event rates are approximately right, and also acts as a benchmark for future validation. 

## Changes or fixes

- `downsamplingStep` is added to the sample config yamls
- `downsamplingStep` is added as a protected attribute to the `SampleHandlerBeamND` and `SampleHandlerBeamFD` classes. This is set via the config yamls in `SampleHandlerBeamND::Init()` and `SampleHandlerBeamFD::Init()`
- The skipping of events and corresponding up-weighting is implemented in the `SampleHandlerBeamND::SetupExperimentMC()` and `SampleHandlerBeamFD::SetupExperimentMC()

## Possible extension

I could extend this to the Atmospheric and NDGAr sampler handlers, but I thought I should wait to see if the relevant people would want that? @dbarrow257 @Jude412 