### PR TITLE
add vdt to dune spack env

### DIFF
--- a/setup_dune_env.sh
+++ b/setup_dune_env.sh
@@ -4,3 +4,6 @@ spack load cmake
 spack load gcc@12.2.0
 
 source /cvmfs/larsoft.opensciencegrid.org/spack-packages/opt/spack/linux-almalinux9-x86_64_v2/gcc-12.2.0/root-6.28.12-sfwfmqorvxttrxgfrfhoq5kplou2pddd/bin/thisroot.sh
+
+spack load vdt@0.4.4
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(spack location -i vdt)/lib


### PR DESCRIPTION
Something has changed on the gpvms and now with ProcessMCMC and DiagMCMC, you get the following error:
```
[chknight@dunegpvm01 build]$ ./bin/ProcessMCMC bin/TutorialDiagConfig.yaml Test.root
./bin/ProcessMCMC: error while loading shared libraries: libvdt.so: cannot open shared object file: No such file or directory
```

With some explicit addition of vdt in the module loading and library path, this is now fixed.