### PR TITLE
bugfix: Revert "unexclude CMakeLists.txt from gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,5 @@ Doc
 Inputs/Atmospherics/CAFs
 nohup.out
 *.txt
-!CMakeLists.txt
 *.log
 .cache/


### PR DESCRIPTION
Reverts DUNE/MaCh3_DUNE#124